### PR TITLE
Fix total number in table for search results

### DIFF
--- a/plugins/view-resources/src/components/Table.svelte
+++ b/plugins/view-resources/src/components/Table.svelte
@@ -230,7 +230,6 @@
     },
     {
       lookup,
-      limit: 1,
       total: true
     }
   )


### PR DESCRIPTION
# Contribution checklist

## Brief description
Total number is wrong for search results in table
<img width="836" alt="image" src="https://github.com/hcengineering/anticrm/assets/45530296/22ee5f09-7c96-4edb-83a7-6acff32ff2cc">
<img width="946" alt="image" src="https://github.com/hcengineering/anticrm/assets/45530296/92eee861-39a5-417f-abe9-f42fefd78a99">

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [x] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues
