### PR TITLE
UBERF-11423: Fix attachments in emails

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2143,9 +2143,6 @@ importers:
       ts-node:
         specifier: ^10.8.0
         version: 10.9.2(@types/node@22.15.29)(typescript@5.3.3)
-      ts-node:
-        specifier: ^10.8.0
-        version: 10.9.2(@types/node@22.15.29)(typescript@5.3.3)
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.15.29)(typescript@5.3.3)
@@ -3977,7 +3974,6 @@ packages:
 
   '@rush-temp/api-client@file:projects/api-client.tgz':
     resolution: {integrity: sha512-UYhM8BEZZAGjh3NN7/AYAown3XJyITGi/Z8J1GOGxuD5121lNpZGcnsfgwa7IsjGZFWQYtJJj5uzEYPxZCYDbA==, tarball: file:projects/api-client.tgz}
-    resolution: {integrity: sha512-UYhM8BEZZAGjh3NN7/AYAown3XJyITGi/Z8J1GOGxuD5121lNpZGcnsfgwa7IsjGZFWQYtJJj5uzEYPxZCYDbA==, tarball: file:projects/api-client.tgz}
     version: 0.0.0
 
   '@rush-temp/api-tests@file:projects/api-tests.tgz':
@@ -4137,7 +4133,6 @@ packages:
     version: 0.0.0
 
   '@rush-temp/datalake@file:projects/datalake.tgz':
-    resolution: {integrity: sha512-6EFAyL58PGeueUU7vysUJ5rqHCRW8pHAJvNCeW/ZY2HhDoFkfv5rLVaioSoGzuzQZR9UPEWxSfohubuFRykBnA==, tarball: file:projects/datalake.tgz}
     resolution: {integrity: sha512-6EFAyL58PGeueUU7vysUJ5rqHCRW8pHAJvNCeW/ZY2HhDoFkfv5rLVaioSoGzuzQZR9UPEWxSfohubuFRykBnA==, tarball: file:projects/datalake.tgz}
     version: 0.0.0
 
@@ -4386,7 +4381,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/mail-common@file:projects/mail-common.tgz':
-    resolution: {integrity: sha512-3mF2CTdNdTUi6sq+KOG6Tz1Jknrfp8+WggKdc/ZSgy3u5ASp8PcXTad3ihjXD0gRatFfrvNI+m3A90gB2zJMNg==, tarball: file:projects/mail-common.tgz}
+    resolution: {integrity: sha512-sdNydMgE2+6RUZLuoxs9vR5TuVhx0ZtgzXtR7GW2AqlG3O31iBo/WyST90ar4jftmjASKrJ4bSObnkuX7dnHyA==, tarball: file:projects/mail-common.tgz}
     version: 0.0.0
 
   '@rush-temp/mail@file:projects/mail.tgz':
@@ -5531,7 +5526,6 @@ packages:
 
   '@rush-temp/tool@file:projects/tool.tgz':
     resolution: {integrity: sha512-r9WMX0Q9Rn6R+gbaZnv2xnbDxEt+3IPyihaoSWmNvKwClND+XChPkAF7DRb3FV9elXvRit1KBALX4Gtn1LIRGQ==, tarball: file:projects/tool.tgz}
-    resolution: {integrity: sha512-r9WMX0Q9Rn6R+gbaZnv2xnbDxEt+3IPyihaoSWmNvKwClND+XChPkAF7DRb3FV9elXvRit1KBALX4Gtn1LIRGQ==, tarball: file:projects/tool.tgz}
     version: 0.0.0
 
   '@rush-temp/tracker-assets@file:projects/tracker-assets.tgz':
@@ -5579,7 +5573,6 @@ packages:
     version: 0.0.0
 
   '@rush-temp/view-resources@file:projects/view-resources.tgz':
-    resolution: {integrity: sha512-0Y8aOf23X/bz1A4vGF6impU0xAGU34E/2D5cZL/9epy4wYlrpMhXPwUUNSXnKSaDvdAjDj7OS1E42d6hZ7DiyA==, tarball: file:projects/view-resources.tgz}
     resolution: {integrity: sha512-0Y8aOf23X/bz1A4vGF6impU0xAGU34E/2D5cZL/9epy4wYlrpMhXPwUUNSXnKSaDvdAjDj7OS1E42d6hZ7DiyA==, tarball: file:projects/view-resources.tgz}
     version: 0.0.0
 
@@ -16760,7 +16753,6 @@ snapshots:
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
       jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
-      jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
       prettier: 3.2.5
       simplytyped: 3.3.0(typescript@5.6.2)
       snappyjs: 0.7.0
@@ -18031,7 +18023,6 @@ snapshots:
       eslint-plugin-import: 2.29.1(eslint@8.56.0)
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
-      jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
       jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
       prettier: 3.2.5
       ts-jest: 29.1.2(@babel/core@7.23.9)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3)))(typescript@5.3.3)
@@ -37159,7 +37150,6 @@ snapshots:
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.15.29
       acorn: 8.14.0
-      acorn: 8.14.0
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -37178,7 +37168,6 @@ snapshots:
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.15.29
       acorn: 8.14.0
-      acorn: 8.14.0
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -37196,7 +37185,6 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.15.29
-      acorn: 8.14.0
       acorn: 8.14.0
       acorn-walk: 8.3.2
       arg: 4.1.3

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2143,6 +2143,9 @@ importers:
       ts-node:
         specifier: ^10.8.0
         version: 10.9.2(@types/node@22.15.29)(typescript@5.3.3)
+      ts-node:
+        specifier: ^10.8.0
+        version: 10.9.2(@types/node@22.15.29)(typescript@5.3.3)
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.15.29)(typescript@5.3.3)
@@ -3974,6 +3977,7 @@ packages:
 
   '@rush-temp/api-client@file:projects/api-client.tgz':
     resolution: {integrity: sha512-UYhM8BEZZAGjh3NN7/AYAown3XJyITGi/Z8J1GOGxuD5121lNpZGcnsfgwa7IsjGZFWQYtJJj5uzEYPxZCYDbA==, tarball: file:projects/api-client.tgz}
+    resolution: {integrity: sha512-UYhM8BEZZAGjh3NN7/AYAown3XJyITGi/Z8J1GOGxuD5121lNpZGcnsfgwa7IsjGZFWQYtJJj5uzEYPxZCYDbA==, tarball: file:projects/api-client.tgz}
     version: 0.0.0
 
   '@rush-temp/api-tests@file:projects/api-tests.tgz':
@@ -4133,6 +4137,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/datalake@file:projects/datalake.tgz':
+    resolution: {integrity: sha512-6EFAyL58PGeueUU7vysUJ5rqHCRW8pHAJvNCeW/ZY2HhDoFkfv5rLVaioSoGzuzQZR9UPEWxSfohubuFRykBnA==, tarball: file:projects/datalake.tgz}
     resolution: {integrity: sha512-6EFAyL58PGeueUU7vysUJ5rqHCRW8pHAJvNCeW/ZY2HhDoFkfv5rLVaioSoGzuzQZR9UPEWxSfohubuFRykBnA==, tarball: file:projects/datalake.tgz}
     version: 0.0.0
 
@@ -5526,6 +5531,7 @@ packages:
 
   '@rush-temp/tool@file:projects/tool.tgz':
     resolution: {integrity: sha512-r9WMX0Q9Rn6R+gbaZnv2xnbDxEt+3IPyihaoSWmNvKwClND+XChPkAF7DRb3FV9elXvRit1KBALX4Gtn1LIRGQ==, tarball: file:projects/tool.tgz}
+    resolution: {integrity: sha512-r9WMX0Q9Rn6R+gbaZnv2xnbDxEt+3IPyihaoSWmNvKwClND+XChPkAF7DRb3FV9elXvRit1KBALX4Gtn1LIRGQ==, tarball: file:projects/tool.tgz}
     version: 0.0.0
 
   '@rush-temp/tracker-assets@file:projects/tracker-assets.tgz':
@@ -5573,6 +5579,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/view-resources@file:projects/view-resources.tgz':
+    resolution: {integrity: sha512-0Y8aOf23X/bz1A4vGF6impU0xAGU34E/2D5cZL/9epy4wYlrpMhXPwUUNSXnKSaDvdAjDj7OS1E42d6hZ7DiyA==, tarball: file:projects/view-resources.tgz}
     resolution: {integrity: sha512-0Y8aOf23X/bz1A4vGF6impU0xAGU34E/2D5cZL/9epy4wYlrpMhXPwUUNSXnKSaDvdAjDj7OS1E42d6hZ7DiyA==, tarball: file:projects/view-resources.tgz}
     version: 0.0.0
 
@@ -16753,6 +16760,7 @@ snapshots:
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
       jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
+      jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
       prettier: 3.2.5
       simplytyped: 3.3.0(typescript@5.6.2)
       snappyjs: 0.7.0
@@ -18023,6 +18031,7 @@ snapshots:
       eslint-plugin-import: 2.29.1(eslint@8.56.0)
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
+      jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
       jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
       prettier: 3.2.5
       ts-jest: 29.1.2(@babel/core@7.23.9)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3)))(typescript@5.3.3)
@@ -20010,6 +20019,7 @@ snapshots:
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-node: 11.1.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
+      image-size: 1.1.1
       jest: 29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
       kafkajs: 2.2.4
       prettier: 3.2.5
@@ -37149,6 +37159,7 @@ snapshots:
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.15.29
       acorn: 8.14.0
+      acorn: 8.14.0
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -37167,6 +37178,7 @@ snapshots:
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.15.29
       acorn: 8.14.0
+      acorn: 8.14.0
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -37184,6 +37196,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.15.29
+      acorn: 8.14.0
       acorn: 8.14.0
       acorn-walk: 8.3.2
       arg: 4.1.3

--- a/services/mail/mail-common/package.json
+++ b/services/mail/mail-common/package.json
@@ -63,6 +63,7 @@
     "kafkajs": "^2.2.4",
     "sanitize-html": "^2.15.0",
     "turndown": "^7.2.0",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "image-size": "^1.1.1"
   }
 }

--- a/services/mail/mail-common/src/message.ts
+++ b/services/mail/mail-common/src/message.ts
@@ -252,11 +252,11 @@ async function saveMessageToSpaces (
       }
 
       const messageId = await createMailMessage(producer, config, messageData, threadId)
+      await createFiles(producer, config, attachments, messageData, threadId, messageId)
       if (!isReply) {
         await addCollaborators(producer, config, messageData, threadId)
         await createMailThread(producer, config, messageData, messageId)
       }
-      await createFiles(producer, config, attachments, messageData, threadId, messageId)
 
       await threadLookup.setThreadId(mailId, space._id, threadId)
     })
@@ -315,7 +315,7 @@ async function createFiles (
   const fileData: Buffer[] = attachments.map((a) => {
     const creeateFileEvent: CreateFileEvent = {
       type: MessageRequestEventType.CreateFile,
-      card: threadId,
+      card: messageData.isReply ? threadId : messageData.channel,
       message: messageId,
       messageCreated: messageData.created,
       creator: messageData.modifiedBy,

--- a/services/mail/mail-common/src/utils.ts
+++ b/services/mail/mail-common/src/utils.ts
@@ -14,9 +14,10 @@
 //
 import TurndownService from 'turndown'
 import sanitizeHtml from 'sanitize-html'
+import { imageSize } from 'image-size'
 
-import { MeasureContext } from '@hcengineering/core'
-import { EmailContact, EmailMessage } from './types'
+import { BlobMetadata, MeasureContext } from '@hcengineering/core'
+import { Attachment, EmailContact, EmailMessage } from './types'
 
 const NAME_EMAIL_PATTERN = /^(?:"?([^"<]+)"?\s*)?<([^>]+)>$/
 const NAME_SEGMENT_REGEX = /[\s,;]+/
@@ -130,4 +131,22 @@ export function parseNameFromEmailHeader (headerValue: string | undefined): Emai
 
 export function normalizeEmail (email: string): string {
   return email.toLowerCase().trim()
+}
+
+export function getBlobMetadata (ctx: MeasureContext, attachment: Attachment): BlobMetadata | undefined {
+  try {
+    const dimensions = imageSize(attachment.data)
+    return dimensions != null
+      ? {
+          originalHeight: dimensions.height,
+          originalWidth: dimensions.width
+        }
+      : undefined
+  } catch (error: any) {
+    ctx.warn('Failed to get blob metadata', {
+      error: error.message,
+      attachmentId: attachment.id
+    })
+    return undefined
+  }
 }


### PR DESCRIPTION
1. Send create file events before create thread event, since it doesn't work in reverse order
2. Temporarily added metadata calculation until it was done on the datalake side
<img width="1377" alt="Screenshot 2025-06-04 at 13 47 49" src="https://github.com/user-attachments/assets/6057c770-44ad-4eda-9697-8fa86233f318" />
