### PR TITLE
Forbid export attempt for readonly users

### DIFF
--- a/services/export/pod-export/src/server.ts
+++ b/services/export/pod-export/src/server.ts
@@ -181,8 +181,13 @@ export function createServer (storageConfig: StorageConfiguration): { app: Expre
         throw new ApiError(400, 'Missing required parameters')
       }
 
+      const decodedToken = decodeToken(token)
+      if (decodedToken.extra?.readonly !== undefined) {
+        throw new ApiError(403, 'Forbidden')
+      }
+
       const platformClient = await createPlatformClient(token)
-      const { account } = decodeToken(token)
+      const account = decodedToken.account
 
       const txOperations = new TxOperations(platformClient, socialId)
 


### PR DESCRIPTION
Even though guest users cannot get data via export, we still should not start the export process for them.