### PR TITLE
Fix false positive emoji detection

### DIFF
--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -56,6 +56,7 @@
     "@hcengineering/ui": "^0.6.15",
     "@hcengineering/uploader": "^0.6.0",
     "@hcengineering/view": "^0.6.13",
+    "@hcengineering/emoji": "^0.6.0",
     "fast-equals": "^5.2.2",
     "png-chunks-extract": "^1.0.0",
     "svelte": "^4.2.19",

--- a/packages/presentation/src/components/markup/NodeContent.svelte
+++ b/packages/presentation/src/components/markup/NodeContent.svelte
@@ -21,6 +21,7 @@
   import MarkdownNode from './MarkdownNode.svelte'
   import Node from './Node.svelte'
   import { getBlobRef } from '../../preview'
+  import { emojiRegex } from '@hcengineering/emoji'
 
   export let node: MarkupNode
   export let single = true
@@ -54,21 +55,12 @@
   }
 
   const checkEmoji = (nodes: MarkupNode[]): boolean => {
-    const matches: boolean[] = []
-    if (nodes.some((node) => node.type !== 'text')) {
-      return false
-    }
-    nodes.forEach((node) => {
-      const reg = node.text?.match(/\P{Emoji}/gu)
-      const regInc = node.text?.match(
-        /\p{Emoji}\uFE0F|\p{Emoji_Presentation}|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?/gu
-      )
-      matches.push(
-        (reg != null && reg.length > 0 && [65039, 65038, 8205].every((code) => code !== reg[0].charCodeAt(0))) ||
-          regInc == null
-      )
-    })
-    return matches.every((m) => !m)
+    if (nodes.length !== 1) return false
+    const match = nodes[0].text?.match(emojiRegex)
+    if (match == null) return false
+    console.log(match[0])
+    console.log(nodes[0].text)
+    return match[0] === nodes[0].text
   }
 </script>
 


### PR DESCRIPTION
This check allows messages with only one emoji to be displayed at a larger size. In some cases, false positives caused text with emoji to be displayed at a larger size.

Before:
![image](https://github.com/user-attachments/assets/90713792-9565-47c2-b406-d420aea29a4b)

After:
![image](https://github.com/user-attachments/assets/fc7c2dbb-ec24-4035-a9eb-e240a514958a)