### PR TITLE
fix: show collaborator connection errors

### DIFF
--- a/plugins/text-editor-assets/lang/cs.json
+++ b/plugins/text-editor-assets/lang/cs.json
@@ -72,6 +72,7 @@
     "SetTextColor": "Nastavit barvu textu",
     "ConvertToLinkPreview": "Zobrazit jako odkaz",
     "ConvertToEmbedPreview": "Zobrazit jako náhled obsahu",
-    "UnableToLoadEmbeddedContent": "Náhled odkazu nelze načíst kvůli nastavení oprávnění nebo nepodporovanému obsahu"
+    "UnableToLoadEmbeddedContent": "Náhled odkazu nelze načíst kvůli nastavení oprávnění nebo nepodporovanému obsahu",
+    "CannotConnectToCollaborationService": "Nelze se připojit k službě spolupráce"
   }
 }

--- a/plugins/text-editor-assets/lang/de.json
+++ b/plugins/text-editor-assets/lang/de.json
@@ -71,6 +71,7 @@
     "SetTextColor": "Textfarbe ändern",
     "ConvertToLinkPreview": "Als Link anzeigen",
     "ConvertToEmbedPreview": "Als Inhaltsvorschau anzeigen",
-    "UnableToLoadEmbeddedContent": "Die Linkvorschau konnte aufgrund von Berechtigungseinstellungen oder nicht unterstütztem Inhalt nicht geladen werden"
+    "UnableToLoadEmbeddedContent": "Die Linkvorschau konnte aufgrund von Berechtigungseinstellungen oder nicht unterstütztem Inhalt nicht geladen werden",
+    "CannotConnectToCollaborationService": "Kann keine Verbindung zum Kollaborationsdienst herstellen"
   }
 }

--- a/plugins/text-editor-assets/lang/en.json
+++ b/plugins/text-editor-assets/lang/en.json
@@ -73,6 +73,7 @@
 
     "ConvertToLinkPreview": "Show as a link",
     "ConvertToEmbedPreview": "Show as a content preview",
-    "UnableToLoadEmbeddedContent": "Link preview couldn't be loaded due to permission settings or unsupported content"
+    "UnableToLoadEmbeddedContent": "Link preview couldn't be loaded due to permission settings or unsupported content",
+    "CannotConnectToCollaborationService": "Cannot connect to collaboration service"
   }
 }

--- a/plugins/text-editor-assets/lang/es.json
+++ b/plugins/text-editor-assets/lang/es.json
@@ -62,6 +62,7 @@
     "DrawingBoard": "Tablero de dibujos",
     "ConvertToLinkPreview": "Mostrar como enlace",
     "ConvertToEmbedPreview": "Mostrar como vista previa de contenido",
-    "UnableToLoadEmbeddedContent": "No se pudo cargar la vista previa del enlace debido a la configuración de permisos o contenido no compatible"
+    "UnableToLoadEmbeddedContent": "No se pudo cargar la vista previa del enlace debido a la configuración de permisos o contenido no compatible",
+    "CannotConnectToCollaborationService": "No se puede conectar con el colaborador"
   }
 }

--- a/plugins/text-editor-assets/lang/fr.json
+++ b/plugins/text-editor-assets/lang/fr.json
@@ -62,6 +62,7 @@
     "DrawingBoard": "Tableau de dessin",
     "ConvertToLinkPreview": "Afficher comme lien",
     "ConvertToEmbedPreview": "Afficher comme aperçu de contenu",
-    "UnableToLoadEmbeddedContent": "L’aperçu du lien n’a pas pu être chargé en raison des paramètres d’autorisation ou d’un contenu non pris en charge"
+    "UnableToLoadEmbeddedContent": "L’aperçu du lien n’a pas pu être chargé en raison des paramètres d’autorisation ou d’un contenu non pris en charge",
+    "CannotConnectToCollaborationService": "Impossible de se connecter au collaborateur"
   }
 }

--- a/plugins/text-editor-assets/lang/it.json
+++ b/plugins/text-editor-assets/lang/it.json
@@ -71,6 +71,7 @@
     "SetTextColor": "Cambia il colore del testo",
     "ConvertToLinkPreview": "Mostra come link",
     "ConvertToEmbedPreview": "Mostra come anteprima del contenuto",
-    "UnableToLoadEmbeddedContent": "Impossibile caricare l'anteprima del link a causa delle impostazioni dei permessi o di contenuto non supportato"
+    "UnableToLoadEmbeddedContent": "Impossibile caricare l'anteprima del link a causa delle impostazioni dei permessi o di contenuto non supportato",
+    "CannotConnectToCollaborationService": "Impossibile connettersi al servizio di collaborazione"
   }
 }

--- a/plugins/text-editor-assets/lang/ja.json
+++ b/plugins/text-editor-assets/lang/ja.json
@@ -73,6 +73,7 @@
 
     "ConvertToLinkPreview": "リンクとして表示",
     "ConvertToEmbedPreview": "コンテンツプレビューとして表示",
-    "UnableToLoadEmbeddedContent": "リンクのプレビューを読み込めません。権限設定または非対応のコンテンツが原因です"
+    "UnableToLoadEmbeddedContent": "リンクのプレビューを読み込めません。権限設定または非対応のコンテンツが原因です",
+    "CannotConnectToCollaborationService": "コラボレーションサービスに接続できません"
   }
 }

--- a/plugins/text-editor-assets/lang/pt.json
+++ b/plugins/text-editor-assets/lang/pt.json
@@ -62,6 +62,7 @@
     "DrawingBoard": "Quadro de desenho",
     "ConvertToLinkPreview": "Mostrar como link",
     "ConvertToEmbedPreview": "Mostrar como pré-visualização de conteúdo",
-    "UnableToLoadEmbeddedContent": "Não foi possível carregar a pré-visualização do link devido às permissões ou a conteúdo não suportado"
+    "UnableToLoadEmbeddedContent": "Não foi possível carregar a pré-visualização do link devido às permissões ou a conteúdo não suportado",
+    "CannotConnectToCollaborationService": "Não foi possível conectar ao serviço de colaboração"
   }
 }

--- a/plugins/text-editor-assets/lang/ru.json
+++ b/plugins/text-editor-assets/lang/ru.json
@@ -72,6 +72,7 @@
     "SetTextColor": "Изменить цвет текста",
     "ConvertToLinkPreview": "Показать как ссылку",
     "ConvertToEmbedPreview": "Показать как превью контента",
-    "UnableToLoadEmbeddedContent": "Не удалось загрузить превью ссылки из-за настроек доступа или неподдерживаемого содержимого"
+    "UnableToLoadEmbeddedContent": "Не удалось загрузить превью ссылки из-за настроек доступа или неподдерживаемого содержимого",
+    "CannotConnectToCollaborationService": "Не удалось подключиться к сервису совместной работы"
   }
 }

--- a/plugins/text-editor-assets/lang/zh.json
+++ b/plugins/text-editor-assets/lang/zh.json
@@ -65,6 +65,7 @@
 
     "ConvertToLinkPreview": "显示为链接",
     "ConvertToEmbedPreview": "显示为内容预览",
-    "UnableToLoadEmbeddedContent": "由于权限设置或不支持的内容，无法加载链接预览"
+    "UnableToLoadEmbeddedContent": "由于权限设置或不支持的内容，无法加载链接预览",
+    "CannotConnectToCollaborationService": "无法连接到协作者"
   }
 }

--- a/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
@@ -152,8 +152,6 @@
 
   let editor: Editor
   let element: HTMLElement
-  let textToolbarElement: HTMLElement
-  let imageToolbarElement: HTMLElement
   let editorPopupContainer: HTMLElement
 
   let placeHolderStr: string = ''
@@ -242,19 +240,12 @@
     needFocus = false
   }
 
-  function handleFocus (): void {
-    needFocus = true
-  }
-
   $: if (editor !== undefined) {
     // When the content is invalid, we don't want to emit an update
     // Preventing synchronization of the invalid content
     const emitUpdate = !contentError
     editor.setEditable(editable, emitUpdate)
   }
-
-  // TODO: should be inside the editor
-  $: showToolbar = canShowPopups
 
   const optionalExtensions: AnyExtension[] = []
 

--- a/plugins/text-editor-resources/src/plugin.ts
+++ b/plugins/text-editor-resources/src/plugin.ts
@@ -15,6 +15,10 @@
 //
 
 import { textEditorId } from '@hcengineering/text-editor'
-import { plugin } from '@hcengineering/platform'
+import { type IntlString, plugin } from '@hcengineering/platform'
 
-export default plugin(textEditorId, {})
+export default plugin(textEditorId, {
+  string: {
+    CannotConnectToCollaborationService: '' as IntlString
+  }
+})


### PR DESCRIPTION
Motivation:
When we cannot connect to collaboration service, users see blank description and no error. This PR shows error message when failed to connect.