### PR TITLE
Fix some issues with livekit connection

### DIFF
--- a/plugins/love-resources/src/liveKitClient.ts
+++ b/plugins/love-resources/src/liveKitClient.ts
@@ -30,10 +30,7 @@ export class LiveKitClient {
   private lastParticipantNotificationTimeout: number = -1
   private lastParticipantDisconnectTimeout: number = -1
 
-  private readonly wsUrl: string
-
   constructor (wsUrl: string) {
-    this.wsUrl = wsUrl
     const lkRoom = new LKRoom({
       adaptiveStream: true,
       dynacast: true,
@@ -62,15 +59,15 @@ export class LiveKitClient {
         }
       }
     })
-    void lkRoom.prepareConnection(this.wsUrl)
+    void lkRoom.prepareConnection(wsUrl)
     lkRoom.on(RoomEvent.Connected, this.onConnected)
     lkRoom.on(RoomEvent.Disconnected, this.onDisconnected)
     this.liveKitRoom = lkRoom
   }
 
-  async connect (token: string, withVideo: boolean): Promise<void> {
+  async connect (wsURL:string, token: string, withVideo: boolean): Promise<void> {
     this.currentSessionSupportsVideo = withVideo
-    await this.liveKitRoom.connect(this.wsUrl, token)
+    await this.liveKitRoom.connect(wsUrl, token)
   }
 
   async disconnect (): Promise<void> {

--- a/plugins/love-resources/src/liveKitClient.ts
+++ b/plugins/love-resources/src/liveKitClient.ts
@@ -65,9 +65,9 @@ export class LiveKitClient {
     this.liveKitRoom = lkRoom
   }
 
-  async connect (wsURL:string, token: string, withVideo: boolean): Promise<void> {
+  async connect (wsURL: string, token: string, withVideo: boolean): Promise<void> {
     this.currentSessionSupportsVideo = withVideo
-    await this.liveKitRoom.connect(wsUrl, token)
+    await this.liveKitRoom.connect(wsURL, token)
   }
 
   async disconnect (): Promise<void> {

--- a/plugins/love-resources/src/utils.ts
+++ b/plugins/love-resources/src/utils.ts
@@ -53,12 +53,7 @@ import { closePanel, getCurrentLocation, navigate, panelstore, showPopup } from 
 import view from '@hcengineering/view'
 import { getObjectLinkFragment } from '@hcengineering/view-resources'
 import { type Widget, type WidgetTab } from '@hcengineering/workbench'
-import {
-  openWidget,
-  openWidgetTab,
-  sidebarStore,
-  updateWidgetState
-} from '@hcengineering/workbench-resources'
+import { openWidget, openWidgetTab, sidebarStore, updateWidgetState } from '@hcengineering/workbench-resources'
 import { isKrispNoiseFilterSupported, KrispNoiseFilter } from '@livekit/krisp-noise-filter'
 import { BackgroundBlur, type BackgroundOptions, type ProcessorWrapper } from '@livekit/track-processors'
 import {

--- a/plugins/love-resources/src/utils.ts
+++ b/plugins/love-resources/src/utils.ts
@@ -54,7 +54,6 @@ import view from '@hcengineering/view'
 import { getObjectLinkFragment } from '@hcengineering/view-resources'
 import { type Widget, type WidgetTab } from '@hcengineering/workbench'
 import {
-  currentWorkspaceStore,
   openWidget,
   openWidgetTab,
   sidebarStore,
@@ -109,13 +108,11 @@ export async function getToken (
 }
 
 function getTokenRoomName (roomName: string, roomId: Ref<Room>): string {
-  const currentWorkspace = get(currentWorkspaceStore)
-
-  if (currentWorkspace == null) {
+  const currentWorkspaceUuid = getMetadata(presentation.metadata.WorkspaceUuid)
+  if (currentWorkspaceUuid === undefined) {
     throw new Error('Current workspace not found')
   }
-
-  return `${currentWorkspace.uuid}_${roomName}_${roomId}`
+  return `${currentWorkspaceUuid}_${roomName}_${roomId}`
 }
 
 export const liveKitClient = getLiveKitClient()
@@ -596,7 +593,8 @@ async function moveToRoom (
 }
 
 async function connectLK (token: string, room: Room): Promise<void> {
-  await liveKitClient.connect(token, room.type === RoomType.Video)
+  const wsURL = getLiveKitEndpoint()
+  await liveKitClient.connect(wsURL, token, room.type === RoomType.Video)
   await Promise.all([
     setMic($myPreferences?.micEnabled ?? lk.remoteParticipants.size < 16),
     setCam(room.type === RoomType.Video && ($myPreferences?.camEnabled ?? true))


### PR DESCRIPTION
- Get WorkspaceUuid from metadata instead of store, @aonnikov reported an error:
<img width="801" height="182" alt="image" src="https://github.com/user-attachments/assets/ecf2406a-3352-4d13-b8b7-b76e30c4849e" />
- love.metadata.WebSocketURL metadata can be set after LiveKitClient creation, so we need to pass it on connection attempt and shouldn't store it in LiveKitClient