### PR TITLE
Refactor handling media devices & permissions

### DIFF
--- a/plugins/love-resources/src/components/ControlBar.svelte
+++ b/plugins/love-resources/src/components/ControlBar.svelte
@@ -48,10 +48,10 @@
     leaveRoom,
     record,
     screenSharing,
-    setShare,
     startTranscription,
     stopTranscription,
-    lk
+    lk,
+    liveKitClient
   } from '../utils'
   import CamSettingPopup from './meeting/CamSettingPopup.svelte'
   import ControlBarContainer from './ControlBarContainer.svelte'
@@ -80,7 +80,7 @@
   async function changeShare (): Promise<void> {
     const newValue = !$isSharingEnabled
     const audio = newValue && $isShareWithSound
-    await setShare(newValue, audio)
+    await liveKitClient.setScreenShareEnabled(newValue, audio)
   }
 
   async function leave (): Promise<void> {

--- a/plugins/love-resources/src/components/RoomPopup.svelte
+++ b/plugins/love-resources/src/components/RoomPopup.svelte
@@ -55,8 +55,8 @@
     isShareWithSound,
     isSharingEnabled,
     leaveRoom,
+    liveKitClient,
     screenSharing,
-    setShare,
     tryConnect
   } from '../utils'
   import { lkSessionConnected } from '../liveKitClient'
@@ -98,7 +98,7 @@
   async function changeShare (): Promise<void> {
     const newValue = !$isSharingEnabled
     const audio = newValue && $isShareWithSound
-    await setShare(newValue, audio)
+    await liveKitClient.setScreenShareEnabled(newValue, audio)
     dispatch('close')
   }
 

--- a/plugins/love-resources/src/components/ShareSettingPopup.svelte
+++ b/plugins/love-resources/src/components/ShareSettingPopup.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Label, Toggle } from '@hcengineering/ui'
   import love from '../plugin'
-  import { setShare, isShareWithSound, isSharingEnabled } from '../utils'
+  import { isShareWithSound, isSharingEnabled, liveKitClient } from '../utils'
 </script>
 
 <div class="antiPopup p-4 grid">
@@ -12,7 +12,7 @@
     on:change={(e) => {
       $isShareWithSound = e.detail
       if ($isSharingEnabled) {
-        setShare($isSharingEnabled, e.detail)
+        void liveKitClient.setScreenShareEnabled($isSharingEnabled, e.detail)
       }
     }}
   />

--- a/plugins/love-resources/src/components/SharingStateIndicator.svelte
+++ b/plugins/love-resources/src/components/SharingStateIndicator.svelte
@@ -16,7 +16,7 @@
   import { tooltip, eventToHTMLElement, showPopup } from '@hcengineering/ui'
 
   import love from '../plugin'
-  import { isSharingEnabled, isShareWithSound, screenSharing, setShare } from '../utils'
+  import { isSharingEnabled, isShareWithSound, screenSharing, liveKitClient } from '../utils'
 
   import SharingStatePopup from './SharingStatePopup.svelte'
   import IconShare from './icons/Share.svelte'
@@ -34,9 +34,7 @@
 
   function handleShare (): void {
     if (disabled) return
-
-    const audio = $isShareWithSound
-    void setShare(true, audio)
+    void liveKitClient.setScreenShareEnabled(true, $isShareWithSound)
   }
 
   $: disabled = !$screenSharing && !$lkSessionConnected

--- a/plugins/love-resources/src/components/SharingStatePopup.svelte
+++ b/plugins/love-resources/src/components/SharingStatePopup.svelte
@@ -19,7 +19,7 @@
   import { createEventDispatcher, onMount } from 'svelte'
 
   import love from '../plugin'
-  import { lk, setShare } from '../utils'
+  import { liveKitClient, lk } from '../utils'
 
   import IconShare from './icons/Share.svelte'
 
@@ -54,7 +54,7 @@
   }
 
   function handleStop (): void {
-    void setShare(false)
+    void liveKitClient.setScreenShareEnabled(false)
     dispatch('close')
   }
 </script>

--- a/plugins/love-resources/src/components/meeting/CamSettingPopup.svelte
+++ b/plugins/love-resources/src/components/meeting/CamSettingPopup.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
-  import { Component, Label, Progress, Toggle } from '@hcengineering/ui'
+  import { Component, Label, Loading, Progress, Toggle } from '@hcengineering/ui'
   import love from '../../plugin'
   import { myPreferences } from '../../stores'
   import { blurProcessor, updateBlurRadius } from '../../utils'
-  import mediaPlugin from '@hcengineering/media'
+  import mediaPlugin, { getMediaDevices } from '@hcengineering/media'
 
   $: blurRadius = $myPreferences?.blurRadius ?? 0
 </script>
 
 <div class="antiPopup mediaPopup">
-  <Component is={mediaPlugin.component.MediaPopupCamSelector} />
+  {#await getMediaDevices(false, true)}
+    <div class="p-4">
+      <Loading />
+    </div>
+  {:then mediaInfo}
+    <Component is={mediaPlugin.component.MediaPopupCamSelector} props={{ mediaInfo }} />
+  {/await}
   {#if blurProcessor !== undefined}
     <div class="grid p-3">
       <Label label={love.string.Blur} />

--- a/plugins/love-resources/src/components/meeting/MicSettingPopup.svelte
+++ b/plugins/love-resources/src/components/meeting/MicSettingPopup.svelte
@@ -2,12 +2,12 @@
   import core, { getCurrentAccount } from '@hcengineering/core'
   import { DevicesPreference } from '@hcengineering/love'
   import { getClient } from '@hcengineering/presentation'
-  import { Component, Label, Toggle } from '@hcengineering/ui'
+  import { Component, Label, Loading, Toggle } from '@hcengineering/ui'
   import { isKrispNoiseFilterSupported } from '@livekit/krisp-noise-filter'
   import love from '../../plugin'
   import { myPreferences } from '../../stores'
   import { krispProcessor } from '../../utils'
-  import mediaPlugin from '@hcengineering/media'
+  import mediaPlugin, { getMediaDevices } from '@hcengineering/media'
 
   const client = getClient()
 
@@ -32,19 +32,25 @@
 </script>
 
 <div class="antiPopup mediaPopup">
-  <Component is={mediaPlugin.component.MediaPopupMicSelector} />
-  <Component is={mediaPlugin.component.MediaPopupSpkSelector} />
-  {#if isKrispNoiseFilterSupported()}
-    <div class="grid p-3">
-      <Label label={love.string.NoiseCancellation} />
-      <Toggle
-        on={$myPreferences?.noiseCancellation ?? true}
-        on:change={(e) => {
-          saveNoiseCancellationPreference($myPreferences, e.detail)
-        }}
-      />
+  {#await getMediaDevices(true, false)}
+    <div class="p-4">
+      <Loading />
     </div>
-  {/if}
+  {:then mediaInfo}
+    <Component is={mediaPlugin.component.MediaPopupMicSelector} props={{ mediaInfo }} />
+    <Component is={mediaPlugin.component.MediaPopupSpkSelector} props={{ mediaInfo }} />
+    {#if isKrispNoiseFilterSupported()}
+      <div class="grid p-3">
+        <Label label={love.string.NoiseCancellation} />
+        <Toggle
+          on={$myPreferences?.noiseCancellation ?? true}
+          on:change={(e) => {
+            saveNoiseCancellationPreference($myPreferences, e.detail)
+          }}
+        />
+      </div>
+    {/if}
+  {/await}
 </div>
 
 <style lang="scss">

--- a/plugins/love-resources/src/components/meeting/ParticipantView.svelte
+++ b/plugins/love-resources/src/components/meeting/ParticipantView.svelte
@@ -244,6 +244,7 @@
     display: none;
   }
   .cover {
+    overflow: hidden;
     object-fit: cover;
     border-radius: 0.75rem;
     height: 100%;

--- a/plugins/love-resources/src/liveKitClient.ts
+++ b/plugins/love-resources/src/liveKitClient.ts
@@ -228,7 +228,7 @@ export class LiveKitClient {
       if (value) {
         const mediaDevices = await getMediaDevices(true, false)
         if (mediaDevices.activeMicrophone !== undefined) {
-          await this.setActiveCamera(mediaDevices.activeMicrophone.deviceId)
+          await this.setActiveMicrophone(mediaDevices.activeMicrophone.deviceId)
           await this.liveKitRoom.localParticipant.setMicrophoneEnabled(true)
         }
       }

--- a/plugins/love-resources/src/liveKitClient.ts
+++ b/plugins/love-resources/src/liveKitClient.ts
@@ -1,6 +1,12 @@
-import { ConnectionState, type RemoteParticipant, Room as LKRoom, RoomEvent } from 'livekit-client'
+import {
+  ConnectionState,
+  type RemoteParticipant,
+  Room as LKRoom,
+  RoomEvent,
+  type VideoCaptureOptions
+} from 'livekit-client'
 import { getMetadata, translate } from '@hcengineering/platform'
-import { getSelectedSpeakerId, type MediaSession } from '@hcengineering/media'
+import { getMediaDevices, getSelectedSpeakerId, type MediaSession } from '@hcengineering/media'
 import { LoveEvents } from '@hcengineering/love'
 import { useMedia } from '@hcengineering/media-resources'
 import { get, writable } from 'svelte/store'
@@ -10,7 +16,7 @@ import { getCurrentLanguage } from '@hcengineering/theme'
 import LastParticipantNotification from './components/meeting/LastParticipantNotification.svelte'
 import love from './plugin'
 import { leaveRoom } from './utils'
-import { myInfo, myOffice } from './stores'
+import { $myPreferences, myInfo, myOffice } from './stores'
 
 export const lkSessionConnected = writable<boolean>(false)
 
@@ -20,6 +26,15 @@ const AUTO_DISCONNECT_DELAY_MS = 60 * 1000
 export function getLiveKitClient (): LiveKitClient {
   const wsURL = getMetadata(love.metadata.WebSocketURL)
   return new LiveKitClient(wsURL ?? '')
+}
+
+const defaultCaptureOptions: VideoCaptureOptions = {
+  facingMode: 'user',
+  resolution: {
+    width: 1280,
+    height: 720,
+    frameRate: 30
+  }
 }
 
 export class LiveKitClient {
@@ -50,14 +65,7 @@ export class LiveKitClient {
       audioOutput: {
         deviceId: getSelectedSpeakerId()
       },
-      videoCaptureDefaults: {
-        facingMode: 'user',
-        resolution: {
-          width: 1280,
-          height: 720,
-          frameRate: 30
-        }
-      }
+      videoCaptureDefaults: defaultCaptureOptions
     })
     void lkRoom.prepareConnection(wsUrl)
     lkRoom.on(RoomEvent.Connected, this.onConnected)
@@ -67,7 +75,45 @@ export class LiveKitClient {
 
   async connect (wsURL: string, token: string, withVideo: boolean): Promise<void> {
     this.currentSessionSupportsVideo = withVideo
-    await this.liveKitRoom.connect(wsURL, token)
+    try {
+      const [, session] = await Promise.all([
+        this.liveKitRoom.connect(wsURL, token, { maxRetries: 3 }),
+        useMedia({
+          state: {
+            camera: this.currentSessionSupportsVideo ? { enabled: $myPreferences?.camEnabled ?? true } : undefined,
+            microphone: { enabled: $myPreferences?.micEnabled ?? this.liveKitRoom.remoteParticipants.size < 16 }
+          },
+          autoDestroy: false
+        })
+      ])
+
+      this.currentMediaSession = session
+      session?.on('camera', (enabled) => {
+        void this.setCameraEnabled(enabled)
+      })
+      session?.on('microphone', (enabled) => {
+        void this.setMicrophoneEnabled(enabled)
+      })
+      session?.on('selected-camera', (deviceId) => {
+        void this.setActiveCamera(deviceId)
+      })
+      session?.on('selected-microphone', (deviceId) => {
+        void this.setActiveMicrophone(deviceId)
+      })
+      session?.on('selected-speaker', (deviceId) => {
+        void this.setActiveSpeaker(deviceId)
+      })
+      session?.on('feature', (feature, enabled) => {
+        if (feature !== 'sharing') return
+        void this.setScreenShareEnabled(enabled, true)
+      })
+
+      await this.updateActiveDevices()
+    } catch (error) {
+      this.currentMediaSession?.close()
+      this.currentMediaSession = undefined
+      throw error
+    }
   }
 
   async disconnect (): Promise<void> {
@@ -76,6 +122,9 @@ export class LiveKitClient {
     await Promise.all([me.setScreenShareEnabled(false), me.setCameraEnabled(false), me.setMicrophoneEnabled(false)])
     await this.liveKitRoom.disconnect()
     this.currentSessionSupportsVideo = false
+    this.currentMediaSession?.close()
+    this.currentMediaSession?.removeAllListeners()
+    this.currentMediaSession = undefined
   }
 
   async awaitConnect (): Promise<void> {
@@ -90,23 +139,12 @@ export class LiveKitClient {
   }
 
   onConnected = (): void => {
-    const session = useMedia({
-      state: {
-        camera: this.currentSessionSupportsVideo ? { enabled: false } : undefined,
-        microphone: { enabled: false }
-      },
-      autoDestroy: false
-    })
     lkSessionConnected.set(true)
-    this.currentMediaSession = session
     this.liveKitRoom.on(RoomEvent.ParticipantConnected, this.onParticipantConnected)
     this.liveKitRoom.on(RoomEvent.ParticipantDisconnected, this.onParticipantDisconnected)
   }
 
   onDisconnected = (): void => {
-    this.currentMediaSession?.close()
-    this.currentMediaSession?.removeAllListeners()
-    this.currentMediaSession = undefined
     lkSessionConnected.set(false)
     this.liveKitRoom.off(RoomEvent.ParticipantConnected, this.onParticipantConnected)
     this.liveKitRoom.off(RoomEvent.ParticipantDisconnected, this.onParticipantDisconnected)
@@ -140,5 +178,68 @@ export class LiveKitClient {
     this.lastParticipantDisconnectTimeout = window.setTimeout(() => {
       void leaveRoom(get(myInfo), get(myOffice))
     }, AUTO_DISCONNECT_DELAY_MS)
+  }
+
+  async updateActiveDevices (): Promise<void> {
+    await this.setActiveCamera(this.currentMediaSession?.state.camera?.deviceId)
+    await this.setActiveMicrophone(this.currentMediaSession?.state.microphone?.deviceId)
+    await this.setCameraEnabled(this.currentMediaSession?.state.camera?.enabled ?? false)
+    await this.setMicrophoneEnabled(this.currentMediaSession?.state.microphone?.enabled ?? false)
+  }
+
+  async setActiveCamera (deviceId: string | undefined): Promise<void> {
+    if (deviceId === undefined || deviceId === null) return
+    if (!this.currentSessionSupportsVideo) return
+    await this.liveKitRoom.switchActiveDevice('videoinput', deviceId, true)
+  }
+
+  async setActiveMicrophone (deviceId: string | undefined): Promise<void> {
+    if (deviceId === undefined || deviceId === null) return
+    await this.liveKitRoom.switchActiveDevice('audioinput', deviceId, true)
+  }
+
+  async setActiveSpeaker (deviceId: string | undefined): Promise<void> {
+    if (deviceId === undefined || deviceId === null) return
+    try {
+      await this.liveKitRoom.switchActiveDevice('audiooutput', deviceId, true)
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  async setCameraEnabled (value: boolean): Promise<void> {
+    try {
+      await this.liveKitRoom.localParticipant.setCameraEnabled(value)
+    } catch (e) {
+      if (value) {
+        const mediaDevices = await getMediaDevices(false, true)
+        if (mediaDevices.activeCamera !== undefined) {
+          await this.setActiveCamera(mediaDevices.activeCamera.deviceId)
+          await this.liveKitRoom.localParticipant.setCameraEnabled(true)
+        }
+      }
+    }
+  }
+
+  async setMicrophoneEnabled (value: boolean): Promise<void> {
+    try {
+      await this.liveKitRoom.localParticipant.setMicrophoneEnabled(value)
+    } catch (e) {
+      if (value) {
+        const mediaDevices = await getMediaDevices(true, false)
+        if (mediaDevices.activeMicrophone !== undefined) {
+          await this.setActiveCamera(mediaDevices.activeMicrophone.deviceId)
+          await this.liveKitRoom.localParticipant.setMicrophoneEnabled(true)
+        }
+      }
+    }
+  }
+
+  async setScreenShareEnabled (value: boolean, withAudio: boolean = false): Promise<void> {
+    try {
+      await this.liveKitRoom.localParticipant.setScreenShareEnabled(value, { audio: withAudio })
+    } catch (e) {
+      console.log(e)
+    }
   }
 }

--- a/plugins/media-resources/src/components/MediaPopup.svelte
+++ b/plugins/media-resources/src/components/MediaPopup.svelte
@@ -20,6 +20,8 @@
   import MediaPopupCamSelector from './MediaPopupCamSelector.svelte'
   import MediaPopupMicSelector from './MediaPopupMicSelector.svelte'
   import MediaPopupSpkSelector from './MediaPopupSpkSelector.svelte'
+  import { getMediaDevices } from '@hcengineering/media'
+  import { Loading } from '@hcengineering/ui'
 
   let micOpened = false
   let camOpened = false
@@ -52,16 +54,21 @@
 
 <div class="antiPopup mediaPopup">
   <ComponentExtensions extension={media.extension.StateContext} on:close />
-
-  <div class="ap-scroll">
-    <div class="ap-box">
-      <MediaPopupMicSelector bind:expanded={micOpened} on:expand={handleMicExpanded} />
-      <div class="separator" />
-      <MediaPopupSpkSelector bind:expanded={spkOpened} on:expand={handleSpkExpanded} />
-      <div class="separator" />
-      <MediaPopupCamSelector bind:expanded={camOpened} on:expand={handleCamExpanded} />
+  {#await getMediaDevices(true, true)}
+    <div class="p-4">
+      <Loading />
     </div>
-  </div>
+  {:then mediaInfo}
+    <div class="ap-scroll">
+      <div class="ap-box">
+        <MediaPopupMicSelector {mediaInfo} bind:expanded={micOpened} on:expand={handleMicExpanded} />
+        <div class="separator" />
+        <MediaPopupSpkSelector {mediaInfo} bind:expanded={spkOpened} on:expand={handleSpkExpanded} />
+        <div class="separator" />
+        <MediaPopupCamSelector {mediaInfo} bind:expanded={camOpened} on:expand={handleCamExpanded} />
+      </div>
+    </div>
+  {/await}
 </div>
 
 <style lang="scss">

--- a/plugins/media-resources/src/components/MediaSettingsButton.svelte
+++ b/plugins/media-resources/src/components/MediaSettingsButton.svelte
@@ -13,10 +13,9 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { requestMediaAccess } from '@hcengineering/media'
   import { IconMoreH, StatusBarButton, showPopup } from '@hcengineering/ui'
 
-  import { camAccess, micAccess, sessions } from '../stores'
+  import { sessions } from '../stores'
 
   import IconCamOn from './icons/CamOn.svelte'
   import MediaPopup from './MediaPopup.svelte'
@@ -26,23 +25,10 @@
 
   $: active = $sessions.length > 0
 
-  async function ensureMediaAccess (): Promise<void> {
-    await $camAccess.ready
-    await $micAccess.ready
-    const requestAudio = $camAccess.state === 'prompt'
-    const requestVideo = $micAccess.state === 'prompt'
-    if (requestAudio || requestVideo) {
-      const kind = requestAudio && requestVideo ? undefined : requestAudio ? 'audioinput' : 'videoinput'
-      await requestMediaAccess(kind)
-    }
-  }
-
   let pressed = false
 
   async function openPopup (): Promise<void> {
     pressed = true
-
-    await ensureMediaAccess()
     showPopup(MediaPopup, {}, anchor, () => {
       pressed = false
     })

--- a/plugins/media/src/utils.ts
+++ b/plugins/media/src/utils.ts
@@ -17,6 +17,31 @@ const selectedCamId = 'selectedDevice_cam'
 const selectedMicId = 'selectedDevice_mic'
 const selectedSpeakerId = 'selectedDevice_speaker'
 
+export interface CamState {
+  enabled: boolean
+  track?: MediaStreamTrack
+  deviceId?: string
+}
+
+export interface MicState {
+  enabled: boolean
+  track?: MediaStreamTrack
+  deviceId?: string
+}
+
+export interface MediaState {
+  camera?: CamState
+  microphone?: MicState
+  [key: string]: any
+}
+
+export interface MediaInfo {
+  activeMicrophone: MediaDeviceInfo | undefined
+  activeCamera: MediaDeviceInfo | undefined
+  activeSpeaker: MediaDeviceInfo | undefined
+  devices: MediaDeviceInfo[]
+}
+
 /** @public */
 export function getSelectedCamId (): string | undefined {
   return localStorage.getItem(selectedCamId) ?? undefined
@@ -59,74 +84,104 @@ export function updateSelectedSpeakerId (deviceId: string | undefined): void {
   }
 }
 
-export interface CamState {
-  enabled: boolean
-  track?: MediaStreamTrack
-  deviceId?: string
-}
-
-export interface MicState {
-  enabled: boolean
-  track?: MediaStreamTrack
-  deviceId?: string
-}
-
-export interface MediaState {
-  camera?: CamState
-  microphone?: MicState
-  [key: string]: any
-}
-
 /** @public */
-export async function requestMediaAccess (kind?: MediaDeviceKind, withAccess?: () => Promise<void>): Promise<boolean> {
+export async function getMediaDevices (microphone: boolean, camera: boolean): Promise<MediaInfo> {
   if (navigator?.mediaDevices === undefined) {
     console.warn('mediaDevices API not available')
-    return false
+    return { activeCamera: undefined, activeMicrophone: undefined, activeSpeaker: undefined, devices: [] }
   }
 
-  try {
-    const stream = await navigator.mediaDevices.getUserMedia({
-      ...(kind !== 'videoinput' ? { audio: true } : undefined),
-      ...(kind !== 'audioinput' && kind !== 'audiooutput' ? { video: true, deviceId: 'default' } : undefined)
-    })
+  let microphonePermission: PermissionStatus['state'] | undefined = microphone
+    ? await getPermissionStatus('microphone')
+    : undefined
+  let cameraPermission: PermissionStatus['state'] | undefined = camera ? await getPermissionStatus('camera') : undefined
+  let selectedMicrophoneId = getSelectedMicId()
+  let selectedCameraId = getSelectedCamId()
+  const selectedSpeakerId = getSelectedSpeakerId()
+  let devices: MediaDeviceInfo[] = []
 
-    try {
-      await withAccess?.()
-    } catch (err) {
-      console.error(err)
+  // firefox returns 'granted' state, but returns empty deviceId, so we need to reask permissions
+  if (microphonePermission === 'granted' || cameraPermission === 'granted') {
+    devices = await enumerateDevices()
+    if (devices.some((d) => d.deviceId === '')) {
+      microphonePermission = microphonePermission === 'granted' ? 'prompt' : microphonePermission
+      cameraPermission = cameraPermission === 'granted' ? 'prompt' : cameraPermission
     }
-
-    releaseStream(stream)
-
-    return true
-  } catch (err) {
-    console.warn('Error accessing media devices:', err)
-    return false
   }
+
+  if (microphonePermission === 'prompt' || cameraPermission === 'prompt') {
+    const askMicrophone = microphonePermission === 'prompt'
+    const askCamera = cameraPermission === 'prompt'
+    try {
+      // ask missing permissions, prefer platform selected devices
+      const stream = await navigator.mediaDevices.getUserMedia({
+        ...(askMicrophone
+          ? {
+              audio:
+                selectedMicrophoneId !== undefined && selectedMicrophoneId !== ''
+                  ? { deviceId: { ideal: selectedMicrophoneId } }
+                  : true
+            }
+          : undefined),
+        ...(askCamera
+          ? {
+              video:
+                selectedCameraId !== undefined && selectedCameraId !== ''
+                  ? { deviceId: { ideal: selectedCameraId } }
+                  : true
+            }
+          : undefined)
+      })
+
+      const tracks = stream.getTracks()
+      if (askMicrophone) {
+        selectedMicrophoneId = tracks.find((t) => t.kind === 'audio')?.getSettings().deviceId
+      }
+      if (askCamera) {
+        selectedCameraId = tracks.find((t) => t.kind === 'video')?.getSettings().deviceId
+      }
+
+      releaseStream(stream)
+    } catch (error) {
+      if (askMicrophone) microphonePermission = 'denied'
+      if (askCamera) cameraPermission = 'denied'
+      console.log(error)
+    }
+  }
+  devices = await enumerateDevices()
+
+  const activeMicrophone =
+    microphonePermission === 'denied' ? undefined : getActiveDevice('audioinput', devices, selectedMicrophoneId)
+  updateSelectedMicId(activeMicrophone?.deviceId)
+  const activeCamera =
+    cameraPermission === 'denied' ? undefined : getActiveDevice('videoinput', devices, selectedCameraId)
+  updateSelectedCamId(activeCamera?.deviceId)
+  const activeSpeaker = getActiveDevice('audiooutput', devices, selectedSpeakerId)
+
+  return { activeMicrophone, activeCamera, activeSpeaker, devices }
 }
 
-/** @public */
-export async function enumerateDevices (kind: MediaDeviceKind, requestPermissions = false): Promise<MediaDeviceInfo[]> {
+function getActiveDevice (
+  kind: MediaDeviceKind,
+  allDevices: MediaDeviceInfo[],
+  deviceId?: string
+): MediaDeviceInfo | undefined {
+  const devices = allDevices.filter((d) => d.kind === kind)
+  if (devices.length === 0) return undefined
+  return devices.find((d) => d.deviceId === deviceId) ?? devices[0]
+}
+
+async function getPermissionStatus (name: 'microphone' | 'camera'): Promise<PermissionStatus['state']> {
+  const status = await navigator.permissions.query({ name })
+  return status.state
+}
+
+async function enumerateDevices (): Promise<MediaDeviceInfo[]> {
   if (navigator?.mediaDevices === undefined) {
     console.warn('mediaDevices API not available')
     return []
   }
-
-  let devices = await navigator.mediaDevices.enumerateDevices()
-  if (requestPermissions) {
-    const noDevices = devices.filter((d) => d.kind === kind).length === 0
-    const noLabel = devices.some((d) => d.kind === kind && d.label === '')
-    if (noDevices || noLabel) {
-      const granted = await requestMediaAccess(kind, async () => {
-        devices = await navigator.mediaDevices.enumerateDevices()
-      })
-      if (!granted) {
-        devices = []
-      }
-    }
-  }
-
-  return devices.filter((d) => d.kind === kind)
+  return await navigator.mediaDevices.enumerateDevices()
 }
 
 export function cleanupDeviceLabel (label: string): string {

--- a/plugins/recorder-resources/src/components/RecordingPopup.svelte
+++ b/plugins/recorder-resources/src/components/RecordingPopup.svelte
@@ -15,7 +15,7 @@
 <script lang="ts">
   import core, { type Blob, type Ref } from '@hcengineering/core'
   import drive, { createFile } from '@hcengineering/drive'
-  import { enumerateDevices } from '@hcengineering/media'
+  import { getMediaDevices } from '@hcengineering/media'
   import { micAccess, camAccess } from '@hcengineering/media-resources'
   import { getEmbeddedLabel } from '@hcengineering/platform'
   import { FilePreview, getClient, MessageBox, SpaceSelector } from '@hcengineering/presentation'
@@ -194,7 +194,8 @@
   }
 
   async function handleCamSetting (e: MouseEvent): Promise<void> {
-    const devices = await enumerateDevices('videoinput')
+    const mediaDevices = await getMediaDevices(false, true)
+    const devices = mediaDevices.devices.filter((d) => d.kind === 'videoinput')
 
     if (devices.length === 0) {
       return
@@ -214,7 +215,8 @@
   }
 
   async function handleMicSetting (e: MouseEvent): Promise<void> {
-    const devices = await enumerateDevices('audioinput')
+    const mediaDevices = await getMediaDevices(true, false)
+    const devices = mediaDevices.devices.filter((d) => d.kind === 'audioinput')
 
     if (devices.length === 0) {
       return


### PR DESCRIPTION
- Some browsers (for example, Firefox) return the permissions granted status, but all device IDs in the list are empty, which means that you need to request permissions again
- Some browsers (again, Firefox) request separate permissions for each device, which leads to a series of separate pop-ups during the start of the call. If we are absolutely sure that the user will use both the camera and the microphone, then we can request permissions in one pop-up.
- When requesting permissions, browsers offer the user a choice of the desired device. This choice must be taken into account. In this case, the device that the user selected within the platform (if selected) must be offered as the default device.
- During an active session, the selected device may become unavailable and we can no longer use it. In this case, we need to get the list of active devices again and, if necessary, request permissions from the user.