### PR TITLE
Fix thread name display

### DIFF
--- a/plugins/card-resources/src/components/CardTagsColored.svelte
+++ b/plugins/card-resources/src/components/CardTagsColored.svelte
@@ -144,7 +144,6 @@
     overflow: hidden;
     align-items: center;
     gap: 0.25rem;
-    width: 100%;
   }
 
   .divider {


### PR DESCRIPTION
Before:
<img width="369" height="347" alt="Screenshot 2025-09-04 at 10 07 57" src="https://github.com/user-attachments/assets/c4a454a7-3abc-4ec0-87e1-50e58e70937c" />

After:
<img width="318" height="337" alt="Screenshot 2025-09-04 at 10 09 48" src="https://github.com/user-attachments/assets/ee670d4e-aaa4-46d3-aceb-7f237b9b8063" />
