### PR TITLE
Desktop App: close tabs with Ctrl+W.

### DIFF
--- a/desktop/src/main/start.ts
+++ b/desktop/src/main/start.ts
@@ -14,7 +14,7 @@
 //
 
 import { config as dotenvConfig } from 'dotenv'
-import { Event, BrowserWindow, CookiesSetDetails, Notification, app, desktopCapturer, dialog, ipcMain, nativeImage, session, shell, systemPreferences, nativeTheme } from 'electron'
+import { globalShortcut, Event, BrowserWindow, CookiesSetDetails, Notification, app, desktopCapturer, dialog, ipcMain, nativeImage, session, shell, systemPreferences, nativeTheme } from 'electron'
 import contextMenu from 'electron-context-menu'
 import log from 'electron-log'
 import Store from 'electron-store'
@@ -22,7 +22,7 @@ import { ProgressInfo, UpdateInfo } from 'electron-updater'
 import WinBadge from 'electron-windows-badge'
 import * as path from 'path'
 
-import { Config, MenuBarAction, NotificationParams, JumpListSpares } from '../ui/types'
+import { Config, MenuBarAction, NotificationParams, JumpListSpares, CommandCloseTab } from '../ui/types'
 import { getOptions } from './args'
 import { addMenus } from './standardMenu'
 import { dispatchMenuBarAction } from './customMenu'
@@ -517,6 +517,10 @@ async function onReady (): Promise<void> {
 
 app.on('ready', () => {
   void onReady()
+
+  globalShortcut.register('CommandOrControl+W', () => {
+    sendCommand(CommandCloseTab)
+  })
 })
 
 app.on('window-all-closed', () => {

--- a/desktop/src/main/start.ts
+++ b/desktop/src/main/start.ts
@@ -518,9 +518,13 @@ async function onReady (): Promise<void> {
 app.on('ready', () => {
   void onReady()
 
-  globalShortcut.register('CommandOrControl+W', () => {
+  const CloseTabHotKey = 'CommandOrControl+W'
+  const registered = globalShortcut.register(CloseTabHotKey, () => {
     sendCommand(CommandCloseTab)
   })
+  if (!registered) {
+    console.log(`failed to register global shortcut on ${CloseTabHotKey}`)
+  }
 })
 
 app.on('window-all-closed', () => {

--- a/desktop/src/main/windowsSpecificSetup.ts
+++ b/desktop/src/main/windowsSpecificSetup.ts
@@ -14,7 +14,7 @@
 //
 
 import { app, JumpListItem, JumpListCategory } from 'electron'
-import { Command, CommandOpenSettings, CommandOpenInbox, CommandOpenApplication, JumpListSpares, WindowAction, SendCommandDelegate, CommandCloseTab } from '../ui/types'
+import { Command, CommandOpenSettings, CommandOpenInbox, CommandOpenApplication, JumpListSpares, WindowAction, SendCommandDelegate } from '../ui/types'
 import * as path from 'path'
 
 const JUMP_COMMANDS = {

--- a/desktop/src/main/windowsSpecificSetup.ts
+++ b/desktop/src/main/windowsSpecificSetup.ts
@@ -14,7 +14,7 @@
 //
 
 import { app, JumpListItem, JumpListCategory } from 'electron'
-import { Command, CommandOpenSettings, CommandOpenInbox, CommandOpenApplication, JumpListSpares, WindowAction, SendCommandDelegate } from '../ui/types'
+import { Command, CommandOpenSettings, CommandOpenInbox, CommandOpenApplication, JumpListSpares, WindowAction, SendCommandDelegate, CommandCloseTab } from '../ui/types'
 import * as path from 'path'
 
 const JUMP_COMMANDS = {

--- a/desktop/src/ui/types.ts
+++ b/desktop/src/ui/types.ts
@@ -85,6 +85,7 @@ export const CommandOpenPlanner = 'open-planner' as const
 export const CommandSelectWorkspace = 'select-workspace' as const
 export const CommandLogout = 'logout' as const
 export const CommandOpenApplication = 'open-application' as const
+export const CommandCloseTab = 'close-tab' as const
 
 export type Command =
   typeof CommandOpenSettings |
@@ -93,7 +94,8 @@ export type Command =
   typeof CommandOpenPlanner |
   typeof CommandSelectWorkspace |
   typeof CommandLogout |
-  typeof CommandOpenApplication
+  typeof CommandOpenApplication |
+  typeof CommandCloseTab
 
 export interface NotificationParams {
   title: string

--- a/models/workbench/src/index.ts
+++ b/models/workbench/src/index.ts
@@ -192,6 +192,19 @@ export function createModel (builder: Builder): void {
       group: 'edit'
     }
   })
+
+  createAction(builder, {
+    action: workbench.actionImpl.CloseCurrentTab,
+    label: presentation.string.Close,
+    icon: view.icon.Delete,
+    keyBinding: ['Meta + keyW', 'Ctrl + keyW'],
+    input: 'none',
+    category: workbench.category.Workbench,
+    allowedForEditableContent: 'always',
+    target: core.class.Doc,
+    context: { mode: ['workbench', 'browser', 'panel', 'editor', 'input'] }
+  },
+  workbench.action.CloseCurrentTab)
 }
 
 export default workbench

--- a/models/workbench/src/index.ts
+++ b/models/workbench/src/index.ts
@@ -193,18 +193,21 @@ export function createModel (builder: Builder): void {
     }
   })
 
-  createAction(builder, {
-    action: workbench.actionImpl.CloseCurrentTab,
-    label: presentation.string.Close,
-    icon: view.icon.Delete,
-    keyBinding: ['Meta + keyW', 'Ctrl + keyW'],
-    input: 'none',
-    category: workbench.category.Workbench,
-    allowedForEditableContent: 'always',
-    target: core.class.Doc,
-    context: { mode: ['workbench', 'browser', 'panel', 'editor', 'input'] }
-  },
-  workbench.action.CloseCurrentTab)
+  createAction(
+    builder,
+    {
+      action: workbench.actionImpl.CloseCurrentTab,
+      label: presentation.string.Close,
+      icon: view.icon.Delete,
+      keyBinding: ['Meta + keyW', 'Ctrl + keyW'],
+      input: 'none',
+      category: workbench.category.Workbench,
+      allowedForEditableContent: 'always',
+      target: core.class.Doc,
+      context: { mode: ['workbench', 'browser', 'panel', 'editor', 'input'] }
+    },
+    workbench.action.CloseCurrentTab
+  )
 }
 
 export default workbench

--- a/models/workbench/src/plugin.ts
+++ b/models/workbench/src/plugin.ts
@@ -40,6 +40,7 @@ export default mergeIds(workbenchId, workbench, {
   actionImpl: {
     PinTab: '' as Resource<(doc?: Doc | Doc[]) => Promise<void>>,
     UnpinTab: '' as Resource<(doc?: Doc | Doc[]) => Promise<void>>,
-    CloseTab: '' as Resource<(doc?: Doc | Doc[]) => Promise<void>>
+    CloseTab: '' as Resource<(doc?: Doc | Doc[]) => Promise<void>>,
+    CloseCurrentTab: '' as Resource<(doc?: Doc | Doc[]) => Promise<void>>
   }
 })

--- a/plugins/workbench-resources/src/index.ts
+++ b/plugins/workbench-resources/src/index.ts
@@ -25,7 +25,7 @@ import Workbench from './components/Workbench.svelte'
 import ServerManager from './components/ServerManager.svelte'
 import WorkbenchTabs from './components/WorkbenchTabs.svelte'
 import { isAdminUser } from '@hcengineering/presentation'
-import { canCloseTab, closeTab, pinTab, unpinTab } from './workbench'
+import { canCloseTab, closeCurrentTab, closeTab, pinTab, unpinTab } from './workbench'
 import { closeWidget, closeWidgetTab, createWidgetTab, getSidebarObject } from './sidebar'
 
 async function hasArchiveSpaces (spaces: Space[]): Promise<boolean> {
@@ -72,6 +72,7 @@ export default async (): Promise<Resources> => ({
     Navigate: doNavigate,
     PinTab: pinTab,
     UnpinTab: unpinTab,
-    CloseTab: closeTab
+    CloseTab: closeTab,
+    CloseCurrentTab: closeCurrentTab
   }
 })

--- a/plugins/workbench-resources/src/workbench.ts
+++ b/plugins/workbench-resources/src/workbench.ts
@@ -194,6 +194,16 @@ export async function closeTab (tab: WorkbenchTab): Promise<void> {
   await client.remove(tab)
 }
 
+export async function closeCurrentTab (): Promise<void> {
+  const tab = get(currentTabStore)
+  if (tab == null) {
+    return
+  }
+  if (canCloseTab(tab)) {
+    await closeTab(tab)
+  }
+}
+
 export async function createTab (): Promise<void> {
   const loc = getCurrentLocation()
   const client = getClient()

--- a/plugins/workbench/src/plugin.ts
+++ b/plugins/workbench/src/plugin.ts
@@ -18,7 +18,7 @@ import type { Class, Doc, Mixin, Ref, Space } from '@hcengineering/core'
 import type { Asset, IntlString, Metadata, Plugin, Resource } from '@hcengineering/platform'
 import { plugin } from '@hcengineering/platform'
 import { AnyComponent, ComponentExtensionId } from '@hcengineering/ui'
-import { ViewAction } from '@hcengineering/view'
+import { Action, ViewAction } from '@hcengineering/view'
 
 import type {
   Application,
@@ -46,6 +46,9 @@ export const workbenchPlugin = plugin(workbenchId, {
   },
   mixin: {
     SpaceView: '' as Ref<Mixin<SpaceView>>
+  },
+  action: {
+    CloseCurrentTab: '' as Ref<Action>
   },
   component: {
     WorkbenchApp: '' as AnyComponent,


### PR DESCRIPTION
This pull request implements a new "Close Current Tab" action and keyboard shortcut (Cmd/Ctrl+W) for the desktop application, ensuring a consistent and platform-integrated way to close the active tab. The changes span the main process, UI, core models, and plugin resources, providing a robust and extensible approach for tab management.

**Keyboard Shortcut and Command Integration**

- Added registration of the `CommandOrControl+W` global shortcut in the Electron main process to trigger the new `close-tab` command, which is sent to the renderer process (`desktop/src/main/start.ts`, `desktop/src/ui/types.ts`). [[1]](diffhunk://#diff-ab0310c1e1dec7c728890ca2a814e0257040697a73b792d5b053b0b58ebdbf2cL17-R25) [[2]](diffhunk://#diff-ab0310c1e1dec7c728890ca2a814e0257040697a73b792d5b053b0b58ebdbf2cR520-R523) [[3]](diffhunk://#diff-7a2330df8f9b4ba505687454c00c1a12a0e92bf7c2551d7f5c70c117b479510dR88) [[4]](diffhunk://#diff-7a2330df8f9b4ba505687454c00c1a12a0e92bf7c2551d7f5c70c117b479510dL96-R98)
- Defined `CommandCloseTab` in shared types and ensured it is handled by the UI process, which delegates to the new platform action (`desktop/src/ui/types.ts`, `desktop/src/ui/index.ts`). [[1]](diffhunk://#diff-7a2330df8f9b4ba505687454c00c1a12a0e92bf7c2551d7f5c70c117b479510dR88) [[2]](diffhunk://#diff-7a2330df8f9b4ba505687454c00c1a12a0e92bf7c2551d7f5c70c117b479510dL96-R98) [[3]](diffhunk://#diff-87f45ea5d8bfc5b22c57ce34769825faf5732a259938d3b61be91fb36ed1a597L23-R30) [[4]](diffhunk://#diff-87f45ea5d8bfc5b22c57ce34769825faf5732a259938d3b61be91fb36ed1a597R140-R143)

**Platform Action and Model Extension**

- Introduced the `CloseCurrentTab` action to the workbench model, including metadata, keybindings, and context, and exposed it via the workbench plugin (`models/workbench/src/index.ts`, `models/workbench/src/plugin.ts`, `plugins/workbench/src/plugin.ts`). [[1]](diffhunk://#diff-0c825ddc397545c5ac63dc33c638910463117aa8e52d2c23fc6ade5e20c0e955R195-R207) [[2]](diffhunk://#diff-897e4708f7ee6601890a8df9d8050485516623cb5626d345f27b70b582b733aaL43-R44) [[3]](diffhunk://#diff-77615d8951b8322a0fdbc867c2d6b240f692af5b7df0d0f7dbcf408431600162R50-R52)

**Resource and Implementation**

- Added the `closeCurrentTab` resource and implementation in the workbench resources plugin, which safely closes the currently active tab if possible (`plugins/workbench-resources/src/workbench.ts`, `plugins/workbench-resources/src/index.ts`). [[1]](diffhunk://#diff-5036d2876797d425e5f867b4f7f715540d5692824e6632d4707425a9a4e35393L28-R28) [[2]](diffhunk://#diff-5036d2876797d425e5f867b4f7f715540d5692824e6632d4707425a9a4e35393L75-R76) [[3]](diffhunk://#diff-05b883887bb344e82019d34ce9c95d85f601ba8a67e193aa538419ad869ac5d0R197-R206)

**Supporting Utilities and Imports**

- Extended imports and utility functions to support the new action and command, including platform resource fetching and action execution (`desktop/src/ui/index.ts`, `desktop/src/main/windowsSpecificSetup.ts`). [[1]](diffhunk://#diff-87f45ea5d8bfc5b22c57ce34769825faf5732a259938d3b61be91fb36ed1a597L5-R5) [[2]](diffhunk://#diff-87f45ea5d8bfc5b22c57ce34769825faf5732a259938d3b61be91fb36ed1a597L23-R30) [[3]](diffhunk://#diff-87f45ea5d8bfc5b22c57ce34769825faf5732a259938d3b61be91fb36ed1a597R40-R52) [[4]](diffhunk://#diff-fe05aadec030b3a60662df83d6d6d5a88a974dde4d47b3d7500833d3d9e17a89L17-R17) [[5]](diffhunk://#diff-77615d8951b8322a0fdbc867c2d6b240f692af5b7df0d0f7dbcf408431600162L21-R21)

These changes provide a seamless and extensible way for users to close the current tab using a familiar keyboard shortcut, aligning with standard desktop application behavior and improving user experience.