### PR TITLE
Support compact display for large messages

### DIFF
--- a/plugins/card-resources/src/components/FeedCardPresenter.svelte
+++ b/plugins/card-resources/src/components/FeedCardPresenter.svelte
@@ -107,7 +107,7 @@
         {#if isCompact}
           <MessagePreview {card} {message} colorInherit />
         {:else}
-          <MessagePresenter {card} {message} hideHeader hideAvatar readonly padding="0" showThreads={false} collapsible={true} />
+          <MessagePresenter {card} {message} hideHeader hideAvatar readonly padding="0" showThreads={false} />
         {/if}
       {/if}
     </div>

--- a/plugins/card-resources/src/components/FeedCardPresenter.svelte
+++ b/plugins/card-resources/src/components/FeedCardPresenter.svelte
@@ -107,7 +107,7 @@
         {#if isCompact}
           <MessagePreview {card} {message} colorInherit />
         {:else}
-          <MessagePresenter {card} {message} hideHeader hideAvatar readonly padding="0" showThreads={false} />
+          <MessagePresenter {card} {message} hideHeader hideAvatar readonly padding="0" showThreads={false} collapsible={true} />
         {/if}
       {/if}
     </div>

--- a/plugins/communication-resources/src/components/message/MessagePresenter.svelte
+++ b/plugins/communication-resources/src/components/message/MessagePresenter.svelte
@@ -45,7 +45,7 @@
   export let hideHeader: boolean = false
   export let readonly: boolean = false
   export let showThreads: boolean = true
-  export let collapsible: boolean = false
+  export let collapsible: boolean = true
   export let maxHeight: string = '30rem'
 
   let isEditing = false

--- a/plugins/communication-resources/src/components/message/MessagePresenter.svelte
+++ b/plugins/communication-resources/src/components/message/MessagePresenter.svelte
@@ -294,7 +294,7 @@
     width: 100%;
     text-align: center;
     color: var(--theme-dark-color);
-    font-size: .8125rem;
+    font-size: 0.8125rem;
     font-weight: 400;
     border-radius: 0.25rem;
     transition: background-color 0.2s ease;

--- a/plugins/communication-resources/src/components/message/MessagePresenter.svelte
+++ b/plugins/communication-resources/src/components/message/MessagePresenter.svelte
@@ -147,7 +147,7 @@
   function checkContentHeight (): void {
     if (messageContainer != null && collapsible && !isExpanded) {
       const scrollHeight = messageContainer.scrollHeight
-      const maxHeightPx = parseFloat(maxHeight.replace('rem', '')) * 16 // Convert rem to px (assuming 16px = 1rem)
+      const maxHeightPx = parseFloat(maxHeight.replace('rem', '')) * 16 // Convert rem to px
       needsExpansion = scrollHeight > maxHeightPx + 20 // 20px threshold
     } else {
       needsExpansion = false

--- a/plugins/communication-resources/src/components/message/MessagePresenter.svelte
+++ b/plugins/communication-resources/src/components/message/MessagePresenter.svelte
@@ -160,7 +160,7 @@
         {card}
         {author}
         {isEditing}
-        compact={compact && message.thread == null}
+        compact={compact && message.threads.length === 0}
         {hideAvatar}
         {hideHeader}
         {showThreads}

--- a/plugins/communication-resources/src/components/message/MessagePresenter.svelte
+++ b/plugins/communication-resources/src/components/message/MessagePresenter.svelte
@@ -190,7 +190,7 @@
         {card}
         {author}
         {isEditing}
-        compact={compact && (message.thread == null || message.thread === undefined)}
+        compact={compact && (message.thread == null)}
         {hideAvatar}
         {hideHeader}
         {showThreads}

--- a/plugins/communication-resources/src/components/message/MessagePresenter.svelte
+++ b/plugins/communication-resources/src/components/message/MessagePresenter.svelte
@@ -23,6 +23,7 @@
   import { getResource } from '@hcengineering/platform'
   import { MessageAction } from '@hcengineering/communication'
   import { Ref } from '@hcengineering/core'
+  import { tick } from 'svelte'
 
   import MessageActionsPanel from './MessageActionsPanel.svelte'
   import MessageBody from './MessageBody.svelte'
@@ -147,7 +148,8 @@
   function checkContentHeight (): void {
     if (messageContainer != null && collapsible && !isExpanded) {
       const scrollHeight = messageContainer.scrollHeight
-      const maxHeightPx = parseFloat(maxHeight.replace('rem', '')) * 16 // Convert rem to px
+      const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize)
+      const maxHeightPx = parseFloat(maxHeight.replace('rem', '')) * rootFontSize
       needsExpansion = scrollHeight > maxHeightPx + 20 // 20px threshold
     } else {
       needsExpansion = false
@@ -161,7 +163,9 @@
 
   // Check content height after message updates
   $: if (message != null && messageContainer != null) {
-    setTimeout(checkContentHeight, 100) // Small delay to ensure content is rendered
+    void tick().then(() => {
+      checkContentHeight()
+    })
   }
 </script>
 
@@ -190,7 +194,7 @@
         {card}
         {author}
         {isEditing}
-        compact={compact && (message.thread == null)}
+        compact={compact && message.thread == null}
         {hideAvatar}
         {hideHeader}
         {showThreads}


### PR DESCRIPTION
Before:
<img width="855" height="775" src="https://github.com/user-attachments/assets/a42d7664-3a33-436d-9445-0271827d7c11" alt="Screenshot 2025-09-26 at 11 42 59">
After:
<img width="722" height="372" src="https://github.com/user-attachments/assets/1c9329de-fd9a-484e-8c7d-592c2e5601da" alt="Screenshot 2025-09-26 at 13 01 30">
<img width="1439" height="794" src="https://github.com/user-attachments/assets/a079bcac-bc3e-4568-8c86-c28a0dffdd15" alt="Screenshot 2025-09-26 at 13 01 44">