### PR TITLE
Use consistent error codes for authorization errors from transaction

### DIFF
--- a/pods/server/src/rpc.ts
+++ b/pods/server/src/rpc.ts
@@ -163,7 +163,7 @@ export function registerRPC (app: Express, sessions: SessionManager, ctx: Measur
 
       const decodedToken = decodeToken(token)
       if (workspaceId !== decodedToken.workspace) {
-        sendError(res, 401, { message: 'Invalid workspace', workspace: decodedToken.workspace })
+        sendError(res, 403, { message: 'Invalid workspace', workspace: decodedToken.workspace })
         return
       }
 
@@ -173,7 +173,7 @@ export function registerRPC (app: Express, sessions: SessionManager, ctx: Measur
         const cs: ConnectionSocket = createClosingSocket(token, rpcSessions)
         const s = await sessions.addSession(ctx, cs, decodedToken, token, token)
         if (!('session' in s)) {
-          sendError(res, 401, {
+          sendError(res, 403, {
             message: 'Failed to create session',
             mode: 'specialError' in s ? s.specialError ?? '' : 'upgrading'
           })

--- a/pods/server/src/server_http.ts
+++ b/pods/server/src/server_http.ts
@@ -321,7 +321,7 @@ export function startHttpServer (
       try {
         const authHeader = req.headers.authorization
         if (authHeader === undefined) {
-          res.status(403).end(JSON.stringify({ error: 'Unauthorized' }))
+          res.status(401).end(JSON.stringify({ error: 'Unauthorized' }))
           return
         }
 
@@ -329,7 +329,7 @@ export function startHttpServer (
         const wsIds = await getWorkspaceIds(token)
 
         if (wsIds.uuid == null) {
-          res.status(401).end(JSON.stringify({ error: 'No workspace found' }))
+          res.status(403).end(JSON.stringify({ error: 'No workspace found' }))
           return
         }
 
@@ -390,7 +390,7 @@ export function startHttpServer (
       try {
         const authHeader = req.headers.authorization
         if (authHeader === undefined) {
-          res.status(403).send({ error: 'Unauthorized' })
+          res.status(401).send({ error: 'Unauthorized' })
           return
         }
 
@@ -398,7 +398,7 @@ export function startHttpServer (
         const wsIds = await getWorkspaceIds(token)
 
         if (wsIds.uuid == null) {
-          res.status(401).send({ error: 'No workspace found' })
+          res.status(403).send({ error: 'No workspace found' })
         }
 
         const name = req.query.name as string


### PR DESCRIPTION
Minor fix, just to make http error codes consistent. 401 Unauthorized - when there is no token, when required, 403 Forbidden - when there is token, but you still can't use operation