### PR TITLE
CLI argument sanitizing: removing trailing slashes in the server URL.

### DIFF
--- a/desktop/src/__test__/main/settings.test.ts
+++ b/desktop/src/__test__/main/settings.test.ts
@@ -159,10 +159,13 @@ describe('Settings', () => {
     })
 
     describe('setServerUrl', () => {
-      test('write than read', () => {
-        const expectedUrl = 'https://new.server.com'
-
-        systemUnderTest.setServerUrl(expectedUrl)
+      const expectedUrl = 'https://new.server.com'
+      test.each([
+        { serverUrl: 'https://new.server.com' },
+        { serverUrl: 'https://new.server.com/' },
+        { serverUrl: 'https://new.server.com//' }
+      ])('write $serverUrl than read', ({ serverUrl }) => {
+        systemUnderTest.setServerUrl(serverUrl)
 
         expect(systemUnderTest.readServerUrl()).toBe(expectedUrl)
       })

--- a/desktop/src/main/settings.ts
+++ b/desktop/src/main/settings.ts
@@ -32,15 +32,9 @@ export class Settings {
   }
 
   readServerUrl (): string {
-    if (this.isDev) {
-      return process.env.FRONT_URL ?? 'http://huly.local:8087'
-    }
-    return (
-      (this.store as any).get(Settings.SETTINGS_KEY_SERVER) as string ??
-      this.packedConfig?.server ??
-      process.env.FRONT_URL ??
-      'https://huly.app'
-    )
+    const url = this.extractUrl()
+    // Motivation: fix existing Huly installations (saved on disk URLs).
+    return Settings.sanitizeUrl(url)
   }
 
   isMinimizeToTrayEnabled (): boolean {
@@ -52,11 +46,8 @@ export class Settings {
   }
 
   setServerUrl (serverUrl: string): void {
-    let cleanUrl: string = serverUrl
-    while (cleanUrl.endsWith('/')) {
-      cleanUrl = cleanUrl.slice(0, -1)
-    }
-    (this.store as any).set(Settings.SETTINGS_KEY_SERVER, cleanUrl)
+    const sanitizedUrl: string = Settings.sanitizeUrl(serverUrl)
+    ;(this.store as any).set(Settings.SETTINGS_KEY_SERVER, sanitizedUrl)
   }
 
   getWindowBounds (): any {
@@ -65,5 +56,25 @@ export class Settings {
 
   setWindowBounds (bounds: any): void {
     (this.store as any).set(Settings.SETTINGS_KEY_WINDOW_BOUNDS, bounds)
+  }
+
+  private extractUrl (): string {
+    if (this.isDev) {
+      return process.env.FRONT_URL ?? 'http://huly.local:8087'
+    }
+    return (
+      (this.store as any).get(Settings.SETTINGS_KEY_SERVER) as string ??
+      this.packedConfig?.server ??
+      process.env.FRONT_URL ??
+      'https://huly.app'
+    )
+  }
+
+  private static sanitizeUrl (serverUrl: string): string {
+    let cleanUrl: string = serverUrl
+    while (cleanUrl.endsWith('/')) {
+      cleanUrl = cleanUrl.slice(0, -1)
+    }
+    return cleanUrl
   }
 }

--- a/desktop/src/main/settings.ts
+++ b/desktop/src/main/settings.ts
@@ -52,7 +52,11 @@ export class Settings {
   }
 
   setServerUrl (serverUrl: string): void {
-    (this.store as any).set(Settings.SETTINGS_KEY_SERVER, serverUrl)
+    let cleanUrl: string = serverUrl
+    while (cleanUrl.endsWith('/')) {
+      cleanUrl = cleanUrl.slice(0, -1)
+    }
+    (this.store as any).set(Settings.SETTINGS_KEY_SERVER, cleanUrl)
   }
 
   getWindowBounds (): any {


### PR DESCRIPTION
This pull request improves the handling and testing of server URLs in the application settings. The main focus is on ensuring that trailing slashes are consistently removed from server URLs before storing them, and updating the corresponding tests to verify this behavior.

**Settings logic improvements:**

* Updated the `setServerUrl` method in `settings.ts` to remove any trailing slashes from the provided `serverUrl` before storing it, ensuring consistent URL formatting.

**Test enhancements:**

* Modified the `setServerUrl` tests in `settings.test.ts` to use parameterized tests (`test.each`) with various forms of server URLs containing trailing slashes, verifying that the stored URL is always normalized.