### PR TITLE
Drawing board control refinement

### DIFF
--- a/packages/presentation/src/___tests___/drawing.test.ts
+++ b/packages/presentation/src/___tests___/drawing.test.ts
@@ -593,5 +593,54 @@ describe('drawing module tests', () => {
         ])
       })
     })
+
+    describe('tools selection', () => {
+      it('select color after panning', () => {
+        const colorsList: ColorsList = [
+          ['alpha', new ThemeAwareColor('red', 'yellow')],
+          ['beta', new ThemeAwareColor('blue', 'blue')]
+        ]
+
+        const toolChangedSpy = jest.fn()
+
+        const initialPenColor: ColorMetaNameOrHex = 'alpha'
+        const systemUnderTest = drawing(drawingPlugInPoint, {
+          colorsList,
+          getCurrentTheme: () => 'theme-light',
+          subscribeOnThemeChange: () => {},
+          readonly: false,
+          imageWidth: 400,
+          imageHeight: 300,
+          commands: [],
+          tool: 'pen',
+          penColor: initialPenColor,
+          toolChanged: toolChangedSpy
+        })
+
+        systemUnderTest.update?.({
+          colorsList,
+          getCurrentTheme: () => 'theme-light',
+          subscribeOnThemeChange: () => {},
+          readonly: false,
+          tool: 'pan',
+          toolChanged: toolChangedSpy
+        })
+
+        expect(toolChangedSpy).toHaveBeenCalledWith('pan')
+        toolChangedSpy.mockClear()
+
+        const newColor: ColorMetaNameOrHex = 'beta'
+        systemUnderTest.update?.({
+          colorsList,
+          getCurrentTheme: () => 'theme-light',
+          subscribeOnThemeChange: () => {},
+          readonly: false,
+          penColor: newColor,
+          toolChanged: toolChangedSpy
+        })
+
+        expect(toolChangedSpy).toHaveBeenCalledWith('pen')
+      })
+    })
   })
 })

--- a/packages/presentation/src/components/DrawingBoard.svelte
+++ b/packages/presentation/src/components/DrawingBoard.svelte
@@ -240,6 +240,9 @@
       cmdDeleted: deleteCommand,
       editorCreated: (editor) => {
         cmdEditor = editor
+      },
+      toolChanged: (newTool) => {
+        tool = newTool
       }
     }}
   >

--- a/packages/presentation/src/components/DrawingBoard.svelte
+++ b/packages/presentation/src/components/DrawingBoard.svelte
@@ -230,6 +230,7 @@
       penWidth,
       eraserWidth,
       fontSize,
+      enableMiddleMousePanning: false,
       changingCmdId,
       cmdAdded: addCommand,
       cmdChanging: showCommandProps,

--- a/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte
+++ b/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte
@@ -261,6 +261,7 @@
         eraserWidth,
         fontSize,
         personCursorPos: personCursorCanvasPos,
+        enableMiddleMousePanning: true,
         changingCmdId,
         cmdAdded: (commandToAdd) => {
           commandsProcessor.addCommand(commandToAdd)

--- a/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte
+++ b/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte
@@ -32,7 +32,6 @@
   import { Loading, Component, themeStore } from '@hcengineering/ui'
   import { onMount, onDestroy } from 'svelte'
   import { Array as YArray, Map as YMap, Doc as YDoc } from 'yjs'
-  import { get } from 'svelte/store'
 
   export let boardId: string
   export let document: YDoc
@@ -288,6 +287,9 @@
         },
         personCursorMoved: (nodePos) => {
           personCursorNodePos = nodePos
+        },
+        toolChanged: (newTool) => {
+          tool = newTool
         }
       }}
     >


### PR DESCRIPTION
This pull request enhances the drawing module with improved tool selection logic and adds support for middle mouse button panning. It also introduces a new callback to notify when the drawing tool changes, and ensures the UI stays in sync with tool state changes. Additionally, new tests have been added to cover the updated tool selection behavior.

**Drawing tool selection and state management:**

* Added a `toolChanged` callback to `DrawingProps` and integrated it into the drawing logic, so consumers are notified whenever the active tool changes. This is now used in both `DrawingBoard.svelte` and `DrawingBoardEditor.svelte` to keep their `tool` state in sync with the drawing module. [[1]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cR71) [[2]](diffhunk://#diff-489ce36df558c3bf6c58422014297beeeebdfc1bfd89d612a82e05cc53f1d16dR244-R246) [[3]](diffhunk://#diff-6723c243c3c121e52c119c4cb0de93419a97608d135b6f9405a551cbc15e7384R291-R293)
* Improved tool switching: when switching away from the pan tool, the previous tool is restored, and changing the pen color while in pan mode automatically switches back to the pen tool. [[1]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cR86) [[2]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cR1058-R1073)

**Middle mouse button panning:**

* Added `enableMiddleMousePanning` to `DrawingProps` and implemented logic to allow panning with the middle mouse button when enabled. This includes new pointer event handling and force-pan logic in the drawing module. [[1]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cR60) [[2]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cR379) [[3]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cR438-R462) [[4]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cL453-R487) [[5]](diffhunk://#diff-6723c243c3c121e52c119c4cb0de93419a97608d135b6f9405a551cbc15e7384R264)
* Updated the drawing logic to distinguish between normal tool actions and forced panning, ensuring correct behavior for pointer and touch events. [[1]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cL401-R406) [[2]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cL410-R416) [[3]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cL420-R427) [[4]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cL475-R519) [[5]](diffhunk://#diff-a3b8ccab71e96ceced608503d6d7550a869cf6a6151683176326fb42d08a5e7cL516-R562)

**Testing:**

* Added a new test to verify that selecting a color after panning correctly switches back to the pen tool and triggers the `toolChanged` callback.

**Minor code cleanup:**

* Removed an unused import from `DrawingBoardEditor.svelte`.