### PR TITLE
Remove redundant tooltip for card type

### DIFF
--- a/plugins/inbox-resources/src/components/InboxCardTitle.svelte
+++ b/plugins/inbox-resources/src/components/InboxCardTitle.svelte
@@ -54,7 +54,7 @@
 <div class="labels">
   {#if client.getHierarchy().isDerived(navItem._class, cardPlugin.class.Card)}
     {@const label = client.getHierarchy().getClass(doc?._class ?? navItem._class).label}
-    <span class="title--bold overflow-label clear-mins" use:tooltip={{ label }}>
+    <span class="title--bold overflow-label clear-mins">
       <Label {label} />
     </span>
     {#if doc}


### PR DESCRIPTION
Remove tooltip for card type, since the card type is already fully visible
<img width="1038" height="500" src="https://github.com/user-attachments/assets/a86f08d9-1833-4da9-9fa0-7626f1957247" alt="image">
It was discussed in thread: https://front.hc.engineering/workbench/platform/chat/6888811b7304837f7d589841_12019797886837%7Ccard%3Aclass%3ACard