### PR TITLE
Back/Forward buttons move into the title bar.

### DIFF
--- a/desktop/src/ui/index.ejs
+++ b/desktop/src/ui/index.ejs
@@ -43,6 +43,10 @@
             --huly-history-box-left-indent: 0;
         }
 
+        .history-box {
+            display: none !important;
+        }
+
         [data-theme="theme-dark"] {
             --bg-body: #1a1928;
             --bg-secondary: #323233;
@@ -207,6 +211,15 @@
             user-select: none;
         }
 
+        .desktop-app-control-button.desktop-app-back,
+        .desktop-app-control-button.desktop-app-forward {
+            font-size: 16px;
+            font-weight: 700;
+            line-height: 1;
+            padding-bottom: 2px;
+            -webkit-text-stroke: 0.5px currentColor;
+        }
+
         .desktop-app-control-button:hover {
             background-color: var(--bg-hover);
         }
@@ -227,6 +240,11 @@
     <div id="desktop-app-titlebar-root">
         <div class="desktop-app-titlebar">
             <div class="desktop-app-menu-container">
+            </div>
+
+            <div class="desktop-app-window-controls">
+                <button class="desktop-app-control-button desktop-app-back" id="back-button" title="Back">←</button>
+                <button class="desktop-app-control-button desktop-app-forward" id="forward-button" title="Forward">→</button>
             </div>
 
             <div class="desktop-app-window-title" id="application-title-bar-caption">Huly</div>

--- a/desktop/src/ui/titleBarMenu.ts
+++ b/desktop/src/ui/titleBarMenu.ts
@@ -365,6 +365,14 @@ class MenuBarManager {
       ipcMain.closeWindow()
     })
 
+    this.onButtonClick('back-button', () => {
+      history.back()
+    })
+
+    this.onButtonClick('forward-button', () => {
+      history.forward()
+    })
+
     document.addEventListener('keydown', (e) => { this.handleKeyDown(ipcMain, e) })
     document.addEventListener('keyup', (e) => { this.handleKeyUp(e) })
 


### PR DESCRIPTION
This pull request updates the desktop application's UI to add navigation controls and make interface adjustments. The most important changes are the addition of "Back" and "Forward" navigation buttons to the window controls, along with styling tweaks, and hiding the `.history-box` element.

**UI Enhancements:**

* Added "Back" and "Forward" navigation buttons to the window controls in the main layout (`index.ejs`). These buttons allow users to navigate through their history within the app.
* Applied custom styles to the new navigation buttons for consistent appearance and improved usability.

**Functionality:**

* Implemented click handlers for the "Back" and "Forward" buttons in `titleBarMenu.ts` to trigger browser history navigation.

**UI Adjustments:**

* Hid the `.history-box` element by default to clean up the interface.