### PR TITLE
Make usage indicator more contrast

### DIFF
--- a/plugins/billing-resources/src/components/LimitsIndicator.svelte
+++ b/plugins/billing-resources/src/components/LimitsIndicator.svelte
@@ -135,6 +135,6 @@
     border-radius: var(--small-BorderRadius);
     transition: background-color 0.2s ease;
     position: relative;
-    border: 1px solid var(--button-secondary-BorderColor);
+    border: 1px solid var(--theme-trans-color);
   }
 </style>

--- a/plugins/billing-resources/src/components/UsageProgressBar.svelte
+++ b/plugins/billing-resources/src/components/UsageProgressBar.svelte
@@ -20,7 +20,7 @@
   $: clampedPercent = Math.min(Math.max(percent, 0), 1)
 
   // Calculate style class based on current percentage
-  $: fillClass = clampedPercent >= 0.9 ? 'critical' : clampedPercent >= 0.5 ? 'warning' : 'normal'
+  $: fillClass = clampedPercent >= 0.9 ? 'critical' : clampedPercent >= 0.7 ? 'warning' : 'normal'
 </script>
 
 <div class="progress-bar" style="width: {width}; height: {height};">

--- a/plugins/billing-resources/src/components/UsageProgressBar.svelte
+++ b/plugins/billing-resources/src/components/UsageProgressBar.svelte
@@ -19,13 +19,13 @@
 
   $: clampedPercent = Math.min(Math.max(percent, 0), 1)
 
-  // Calculate color based on current percentage
-  $: fillColor = clampedPercent >= 0.9 ? '#e53935' : clampedPercent >= 0.7 ? '#fbc02d' : '#43a047'
+  // Calculate style class based on current percentage
+  $: fillClass = clampedPercent >= 0.9 ? 'critical' : clampedPercent >= 0.5 ? 'warning' : 'normal'
 </script>
 
 <div class="progress-bar" style="width: {width}; height: {height};">
   <div class="progress-track">
-    <div class="progress-fill" style="width: {clampedPercent * 100}%; background-color: {fillColor};"></div>
+    <div class="progress-fill {fillClass}" style="width: {clampedPercent * 100}%;"></div>
   </div>
 </div>
 
@@ -49,5 +49,17 @@
     transition:
       width 0.3s ease,
       background-color 0.3s ease;
+
+    &.normal {
+      background-color: var(--theme-won-color);
+    }
+
+    &.warning {
+      background-color: var(--theme-warning-color);
+    }
+
+    &.critical {
+      background-color: var(--theme-error-color);
+    }
   }
 </style>


### PR DESCRIPTION
Before:
<img width="358" height="44" src="https://github.com/user-attachments/assets/c60b447c-9ed7-4ab5-a1b8-bdb166169435" alt="Screenshot 2025-11-04 at 07 51 09">

After:
<img width="339" height="34" src="https://github.com/user-attachments/assets/35c52eaa-73c9-40c4-b2d9-3ebc6aeebc5f" alt="Screenshot 2025-11-04 at 08 09 24">