### PR TITLE
Fix unstable QMS login tests

### DIFF
--- a/plugins/login-resources/src/components/Form.svelte
+++ b/plugins/login-resources/src/components/Form.svelte
@@ -45,9 +45,10 @@
   export let withProviders: boolean = false
   export let subtitle: string | undefined = undefined
   export let signUpDisabled = false
+  export let isLoading: boolean = false
 
   const validate = makeSequential(async function validateAsync (language: string): Promise<boolean> {
-    if (ignoreInitialValidation) return true
+    if (ignoreInitialValidation || isLoading) return true
 
     for (const field of fields) {
       const v = object[field.name]

--- a/plugins/login-resources/src/components/LoginPasswordForm.svelte
+++ b/plugins/login-resources/src/components/LoginPasswordForm.svelte
@@ -48,24 +48,30 @@
   }
 
   let status = OK
+  let isLoading = false
 
   const action = {
     i18n: login.string.LogIn,
     func: async () => {
-      status = new Status(Severity.INFO, login.status.ConnectingToServer, {})
-      const [loginStatus, result] = await doLogin(object.username, object.password)
-      status = loginStatus
+      isLoading = true
+      try {
+        status = new Status(Severity.INFO, login.status.ConnectingToServer, {})
+        const [loginStatus, result] = await doLogin(object.username, object.password)
+        status = loginStatus
 
-      if (onLogin !== undefined) {
-        void onLogin(result, status)
-      } else {
-        await doLoginNavigate(
-          result,
-          (st) => {
-            status = st
-          },
-          navigateUrl
-        )
+        if (onLogin !== undefined) {
+          void onLogin(result, status)
+        } else {
+          await doLoginNavigate(
+            result,
+            (st) => {
+              status = st
+            },
+            navigateUrl
+          )
+        }
+      } finally {
+        isLoading = false
       }
     }
   }
@@ -79,6 +85,7 @@
   {object}
   {action}
   {signUpDisabled}
+  {isLoading}
   bottomActions={[recoveryAction]}
   ignoreInitialValidation
   withProviders

--- a/qms-tests/sanity/tests/model/login-page.ts
+++ b/qms-tests/sanity/tests/model/login-page.ts
@@ -26,6 +26,10 @@ export class LoginPage {
   async login (email: string, password: string): Promise<void> {
     await this.inputEmail.fill(email)
     await this.inputPassword.fill(password)
+
+    // Wait for form validation to complete
+    await this.page.waitForTimeout(1000)
+
     expect(await this.buttonLogin.isEnabled()).toBe(true)
     await this.buttonLogin.click()
   }


### PR DESCRIPTION
  3) [QMS] › tests/documents/ES-40.2.spec.ts:27:7 › login test › TESTS-397 - Wrong email and correct password: I cannot log in 

    Error: expect(locator).toContainText(expected) failed

    Locator: getByText('Account not found or the provided credentials are incorrect')
    Expected substring: "Account not found or the provided credentials are incorrect"
    Timeout: 5000ms