### PR TITLE
Remove notifications migration

### DIFF
--- a/models/notification/src/migration.ts
+++ b/models/notification/src/migration.ts
@@ -313,7 +313,7 @@ async function migrateCollaborators (client: MigrationClient): Promise<void> {
 
 async function migrateReactionNotifications (client: MigrationClient): Promise<void> {
   /*
-    Do nothining for now, since previos implementation was very slow and caused issues in production.
+    Do nothing for now, since previos implementation was very slow and caused issues in production.
     Old inbox is used in production now, so later add a tool to migrate old reaction notifications if needed.
     TODO: UBERF-14185
   */

--- a/models/notification/src/migration.ts
+++ b/models/notification/src/migration.ts
@@ -313,7 +313,7 @@ async function migrateCollaborators (client: MigrationClient): Promise<void> {
 
 async function migrateReactionNotifications (client: MigrationClient): Promise<void> {
   /*
-    Do nothing for now, since previos implementation was very slow and caused issues in production.
+    Do nothing for now, since previous implementation was very slow and caused issues in production.
     Old inbox is used in production now, so later add a tool to migrate old reaction notifications if needed.
     TODO: UBERF-14185
   */


### PR DESCRIPTION
Do nothing for now due to the following:
- previous implementation was very slow and caused issues in production
- old communication is used now on Huly and for self-hosters, so it is not required

Lets add a migration tool with fixed performance later