### PR TITLE
Ignore legacy JS Api warnings in Svelte preprocess

### DIFF
--- a/packages/highlight/svelte.config.js
+++ b/packages/highlight/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/packages/hls/svelte.config.js
+++ b/packages/hls/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/packages/kanban/svelte.config.js
+++ b/packages/kanban/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/packages/panel/svelte.config.js
+++ b/packages/panel/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/packages/presentation/svelte.config.js
+++ b/packages/presentation/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/packages/theme/svelte.config.js
+++ b/packages/theme/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/packages/ui/svelte.config.js
+++ b/packages/ui/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/achievement-resources/svelte.config.js
+++ b/plugins/achievement-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/activity-resources/svelte.config.js
+++ b/plugins/activity-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/ai-assistant-resources/svelte.config.js
+++ b/plugins/ai-assistant-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/ai-bot-resources/svelte.config.js
+++ b/plugins/ai-bot-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/analytics-collector-resources/svelte.config.js
+++ b/plugins/analytics-collector-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/attachment-resources/svelte.config.js
+++ b/plugins/attachment-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/billing-resources/svelte.config.js
+++ b/plugins/billing-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/bitrix-resources/svelte.config.js
+++ b/plugins/bitrix-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/board-resources/svelte.config.js
+++ b/plugins/board-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/calendar-resources/svelte.config.js
+++ b/plugins/calendar-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/card-resources/svelte.config.js
+++ b/plugins/card-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/chat-resources/svelte.config.js
+++ b/plugins/chat-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/chunter-resources/svelte.config.js
+++ b/plugins/chunter-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/communication-resources/svelte.config.js
+++ b/plugins/communication-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/contact-resources/svelte.config.js
+++ b/plugins/contact-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/controlled-documents-resources/svelte.config.js
+++ b/plugins/controlled-documents-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/desktop-downloads-resources/svelte.config.js
+++ b/plugins/desktop-downloads-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/desktop-preferences-resources/svelte.config.js
+++ b/plugins/desktop-preferences-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/devmodel-resources/svelte.config.js
+++ b/plugins/devmodel-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/diffview-resources/svelte.config.js
+++ b/plugins/diffview-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/document-resources/svelte.config.js
+++ b/plugins/document-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/drive-resources/svelte.config.js
+++ b/plugins/drive-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/emoji-resources/svelte.config.js
+++ b/plugins/emoji-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/export-resources/svelte.config.js
+++ b/plugins/export-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/global-profile-resources/svelte.config.js
+++ b/plugins/global-profile-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/gmail-resources/svelte.config.js
+++ b/plugins/gmail-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/guest-resources/svelte.config.js
+++ b/plugins/guest-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/hr-resources/svelte.config.js
+++ b/plugins/hr-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/huly-mail-resources/svelte.config.js
+++ b/plugins/huly-mail-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/image-cropper-resources/svelte.config.js
+++ b/plugins/image-cropper-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/inbox-resources/svelte.config.js
+++ b/plugins/inbox-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/inventory-resources/svelte.config.js
+++ b/plugins/inventory-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/lead-resources/svelte.config.js
+++ b/plugins/lead-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/login-resources/svelte.config.js
+++ b/plugins/login-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/love-resources/svelte.config.js
+++ b/plugins/love-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/media-resources/svelte.config.js
+++ b/plugins/media-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/notification-resources/svelte.config.js
+++ b/plugins/notification-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/notification/svelte.config.js
+++ b/plugins/notification/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/onboard-resources/svelte.config.js
+++ b/plugins/onboard-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/presence-resources/svelte.config.js
+++ b/plugins/presence-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/print-resources/svelte.config.js
+++ b/plugins/print-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/process-resources/svelte.config.js
+++ b/plugins/process-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/products-resources/svelte.config.js
+++ b/plugins/products-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/questions-resources/svelte.config.js
+++ b/plugins/questions-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/rating-resources/svelte.config.js
+++ b/plugins/rating-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/recorder-resources/svelte.config.js
+++ b/plugins/recorder-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/recruit-resources/svelte.config.js
+++ b/plugins/recruit-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/request-resources/svelte.config.js
+++ b/plugins/request-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/setting-resources/svelte.config.js
+++ b/plugins/setting-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/support-resources/svelte.config.js
+++ b/plugins/support-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/survey-resources/svelte.config.js
+++ b/plugins/survey-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/tags-resources/svelte.config.js
+++ b/plugins/tags-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/task-resources/svelte.config.js
+++ b/plugins/task-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/telegram-resources/svelte.config.js
+++ b/plugins/telegram-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/templates-resources/svelte.config.js
+++ b/plugins/templates-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/test-management-resources/svelte.config.js
+++ b/plugins/test-management-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/text-editor-resources/svelte.config.js
+++ b/plugins/text-editor-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/time-resources/svelte.config.js
+++ b/plugins/time-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/tracker-resources/svelte.config.js
+++ b/plugins/tracker-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/training-resources/svelte.config.js
+++ b/plugins/training-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/uploader-resources/svelte.config.js
+++ b/plugins/uploader-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/view-resources/svelte.config.js
+++ b/plugins/view-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/plugins/workbench-resources/svelte.config.js
+++ b/plugins/workbench-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/services/github/github-resources/svelte.config.js
+++ b/services/github/github-resources/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };

--- a/services/payment/pod-payment/tsconfig.json
+++ b/services/payment/pod-payment/tsconfig.json
@@ -5,9 +5,7 @@
     "rootDir": "./src",
     "outDir": "./lib",
     "declarationDir": "./types",
-    "tsBuildInfoFile": ".build/build.tsbuildinfo",
-    "module": "node16",
-    "moduleResolution": "node16"
+    "tsBuildInfoFile": ".build/build.tsbuildinfo"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "lib", "dist", "types", "bundle"]

--- a/services/payment/pod-payment/tsconfig.json
+++ b/services/payment/pod-payment/tsconfig.json
@@ -5,7 +5,9 @@
     "rootDir": "./src",
     "outDir": "./lib",
     "declarationDir": "./types",
-    "tsBuildInfoFile": ".build/build.tsbuildinfo"
+    "tsBuildInfoFile": ".build/build.tsbuildinfo",
+    "module": "node16",
+    "moduleResolution": "node16"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "lib", "dist", "types", "bundle"]

--- a/templates/ui/svelte.config.js
+++ b/templates/ui/svelte.config.js
@@ -1,5 +1,10 @@
 const sveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
-    preprocess: sveltePreprocess()
+    preprocess: sveltePreprocess({
+      scss: {
+          // This is expected as svelte-preprocess hasn't fully migrated to the modern API yet
+          silenceDeprecations: ['legacy-js-api']
+      }
+    })
 };


### PR DESCRIPTION
Ignore legacy JS api warnings in Svelte preprocess, since there is no Svelte preprocess version with modern API support and this makes it difficult to read the logs:

```
DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/legacy-js-api

DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
```