### PR TITLE
fix: show custom icons for cards breadcrumbs

### DIFF
--- a/plugins/card-resources/src/components/Main.svelte
+++ b/plugins/card-resources/src/components/Main.svelte
@@ -16,8 +16,9 @@
   import { MasterTag } from '@hcengineering/card'
   import { Class, Doc, Ref, Space } from '@hcengineering/core'
   import { IntlString } from '@hcengineering/platform'
-  import { createQuery } from '@hcengineering/presentation'
+  import { createQuery, IconWithEmoji } from '@hcengineering/presentation'
   import { location } from '@hcengineering/ui'
+  import view from '@hcengineering/view'
   import { SpecialView } from '@hcengineering/workbench-resources'
   import { onDestroy } from 'svelte'
   import card from '../plugin'
@@ -54,6 +55,7 @@
     baseQuery={space !== undefined ? { space } : {}}
     {space}
     {label}
-    icon={clazz.icon ?? card.icon.Card}
+    icon={clazz.icon === view.ids.IconWithEmoji ? IconWithEmoji : clazz.icon}
+    iconProps={clazz.icon === view.ids.IconWithEmoji ? { icon: clazz.color } : {}}
   />
 {/if}

--- a/plugins/workbench-resources/src/components/SpecialView.svelte
+++ b/plugins/workbench-resources/src/components/SpecialView.svelte
@@ -18,6 +18,7 @@
   import { getClient, ComponentExtensions } from '@hcengineering/presentation'
   import {
     AnyComponent,
+    AnySvelteComponent,
     Breadcrumb,
     Button,
     Component,
@@ -41,10 +42,12 @@
   import workbench, { ParentsNavigationModel } from '@hcengineering/workbench'
   import ComponentNavigator from './ComponentNavigator.svelte'
   import { deepEqual } from 'fast-equals'
+  import { ComponentType } from 'svelte'
 
   export let _class: Ref<Class<Doc>>
   export let space: Ref<Space> | undefined = undefined
-  export let icon: Asset
+  export let icon: Asset | AnySvelteComponent | ComponentType | undefined = undefined
+  export let iconProps: any | undefined = undefined
   export let label: IntlString
   export let createEvent: string | undefined = undefined
   export let createLabel: IntlString | undefined = undefined
@@ -153,7 +156,7 @@
     <ViewletSettingButton bind:viewOptions bind:viewlet {defaultViewOptions} {defaultConfig} />
   </svelte:fragment>
 
-  <Breadcrumb {icon} {label} size={'large'} isCurrent />
+  <Breadcrumb {icon} {iconProps} {label} size={'large'} isCurrent />
 
   <svelte:fragment slot="search">
     <SearchInput bind:value={search} collapsed />


### PR DESCRIPTION
Fixes broken icons:
<img width="738" height="160" src="https://github.com/user-attachments/assets/01d23bac-be8b-44d3-8b8f-d3bdface0f2d" alt="Screenshot 2026-01-17 at 14 18 20">