### PR TITLE
Fix long title display

### DIFF
--- a/packages/presentation/src/components/NavLink.svelte
+++ b/packages/presentation/src/components/NavLink.svelte
@@ -134,6 +134,7 @@
       display: inline-flex;
       align-items: center;
       text-decoration: none;
+      max-width: 100%;
     }
 
     &.inlineBlock {


### PR DESCRIPTION
Before:
<img width="1439" height="454" src="https://github.com/user-attachments/assets/ffad0b0e-4227-4ac3-ae83-520f1183566b" alt="Screenshot 2026-01-19 at 16 19 48">
After:
<img width="1440" height="402" src="https://github.com/user-attachments/assets/92130bfe-5986-4e6d-b01c-cdb1199e844c" alt="Screenshot 2026-01-19 at 16 19 37">