### PR TITLE
Add activity section in controlled doc

### DIFF
--- a/plugins/controlled-documents-resources/src/components/document/EditDocContent.svelte
+++ b/plugins/controlled-documents-resources/src/components/document/EditDocContent.svelte
@@ -28,10 +28,11 @@
     highlightUpdateCommand,
     selectNode
   } from '@hcengineering/text-editor-resources'
-  import { EditBox, Label, Scroller } from '@hcengineering/ui'
+  import { Component, EditBox, Label, Scroller } from '@hcengineering/ui'
   import { getCollaborationUser } from '@hcengineering/view-resources'
   import { merge } from 'effector'
   import { createEventDispatcher, onDestroy, tick } from 'svelte'
+  import activity from '@hcengineering/activity'
   import plugin from '../../plugin'
 
   import {
@@ -41,11 +42,13 @@
     $controlledDocument as controlledDocument,
     $documentCommentHighlightedLocation as documentCommentHighlightedLocation,
     $documentComments as documentComments,
+    $documentState as documentState,
     documentCommentsDisplayRequested,
     documentCommentsLocationNavigateRequested,
     documentCommentsAddCanceled,
     $isEditable as isEditable
   } from '../../stores/editors/document'
+  import { isActivityDocumentState } from '../../utils'
   import DocumentPrintTitlePage from '../print/DocumentPrintTitlePage.svelte'
   import DocumentTitle from './DocumentTitle.svelte'
 
@@ -276,6 +279,19 @@
             return await createEmbedding(file)
           }}
         />
+        {#if isActivityDocumentState($documentState)}
+          <div class="activity-container no-print">
+            <Component
+              is={activity.component.Activity}
+              props={{
+                object: $controlledDocument,
+                showCommenInput: true,
+                boundary,
+                focusIndex: 1000
+              }}
+            />
+          </div>
+        {/if}
         <div class="bottomSpacing no-print" />
       </div>
     </Scroller>
@@ -338,6 +354,10 @@
 
   .bottomSpacing {
     padding-bottom: 55vh;
+  }
+
+  .activity-container {
+    padding-top: 2rem;
   }
 
   .watermark-container {

--- a/plugins/controlled-documents-resources/src/utils.ts
+++ b/plugins/controlled-documents-resources/src/utils.ts
@@ -536,6 +536,15 @@ export const controlledDocumentStatesOrder = [
   ControlledDocumentState.ToReview
 ]
 
+const activityDocumentStates = [
+  DocumentState.Draft,
+  ControlledDocumentState.InReview,
+  ControlledDocumentState.Reviewed,
+  ControlledDocumentState.InApproval,
+  ControlledDocumentState.Approved,
+  ControlledDocumentState.Rejected
+]
+
 export interface LoginInfo {
   email: string
   password: string
@@ -1232,4 +1241,11 @@ export async function extractValidationWorkflow (
   }
 
   return result
+}
+
+export function isActivityDocumentState (state: DocumentState | ControlledDocumentState | null): boolean {
+  if (state == null) {
+    return false
+  }
+  return activityDocumentStates.includes(state)
 }

--- a/plugins/controlled-documents-resources/src/utils.ts
+++ b/plugins/controlled-documents-resources/src/utils.ts
@@ -541,7 +541,6 @@ const activityDocumentStates = [
   ControlledDocumentState.InReview,
   ControlledDocumentState.Reviewed,
   ControlledDocumentState.InApproval,
-  ControlledDocumentState.Approved,
   ControlledDocumentState.Rejected
 ]
 


### PR DESCRIPTION
Add activity section in controlled doc (like in docs) in draft, review, phases BUT NOT when the doc is effective or archived (only when the doc is being worked on)

<img width="1440" height="814" src="https://github.com/user-attachments/assets/2dbb047e-9d84-4445-8b65-22ceea389ff0" alt="Screenshot 2026-01-28 at 13 47 15">
