### PR TITLE
Fix exception during github issue id reading

### DIFF
--- a/services/github/pod-github/src/sync/issues.ts
+++ b/services/github/pod-github/src/sync/issues.ts
@@ -939,7 +939,9 @@ export class IssueSyncManager extends IssueSyncManagerBase implements DocSyncMan
           break
         }
         const docsPart = allSyncDocs.splice(0, partsize)
-        const idsPart = docsPart.map((it) => (it.external as IssueExternalData).id).filter((it) => it !== undefined)
+        const idsPart = docsPart
+          .map((it) => (it.external as IssueExternalData | undefined)?.id)
+          .filter((id): id is string => id !== undefined)
         if (idsPart.length === 0) {
           break
         }
@@ -986,7 +988,7 @@ export class IssueSyncManager extends IssueSyncManagerBase implements DocSyncMan
             })
           } else if (partsize === 1) {
             // We need to update issue, since it is missing on external side.
-            const syncDoc = syncDocs.find((it) => it.external.id === idsPart[0])
+            const syncDoc = syncDocs.find((it) => it.external?.id === idsPart[0])
             if (syncDoc !== undefined) {
               ctx.warn('mark missing external PR', {
                 errors: err.errors,
@@ -1008,7 +1010,7 @@ export class IssueSyncManager extends IssueSyncManagerBase implements DocSyncMan
         }
       }
       for (const d of syncDocs) {
-        if ((d.external as IssueExternalData).id == null) {
+        if ((d.external as IssueExternalData)?.id == null) {
           ctx.error('failed to do external sync for', { objectClass: d.objectClass, _id: d._id })
           // no external data for doc
           await derivedClient.update<DocSyncInfo>(d, {

--- a/services/github/pod-github/src/sync/pullrequests.ts
+++ b/services/github/pod-github/src/sync/pullrequests.ts
@@ -1319,7 +1319,9 @@ export class PullRequestSyncManager extends IssueSyncManagerBase implements DocS
     try {
       while (true) {
         const docsPart = allSyncDocs.splice(0, partsize)
-        const idsPart = docsPart.map((it) => (it.external as IssueExternalData).id).filter((it) => it !== undefined)
+        const idsPart = docsPart
+          .map((it) => (it.external as IssueExternalData | undefined)?.id)
+          .filter((id): id is string => id !== undefined)
         if (idsPart.length === 0) {
           break
         }
@@ -1366,7 +1368,7 @@ export class PullRequestSyncManager extends IssueSyncManagerBase implements DocS
             })
           } else if (partsize === 1) {
             // We need to update issue, since it is missing on external side.
-            const syncDoc = syncDocs.find((it) => it.external.id === idsPart[0])
+            const syncDoc = syncDocs.find((it) => it.external?.id === idsPart[0])
             if (syncDoc !== undefined) {
               ctx.warn('mark missing external PR', {
                 errors: err.errors,
@@ -1388,7 +1390,7 @@ export class PullRequestSyncManager extends IssueSyncManagerBase implements DocS
         }
       }
       for (const d of syncDocs) {
-        if ((d.external as IssueExternalData).id == null) {
+        if ((d.external as IssueExternalData | undefined)?.id == null) {
           ctx.error('failed to do external sync for', { objectClass: d.objectClass, _id: d._id })
           // no external data for doc
           await derivedClient.update<DocSyncInfo>(d, {


### PR DESCRIPTION
Fix errors from github service logs:

```
{"err":{"message":"Cannot read properties of undefined (reading 'id')","stack":"TypeError: Cannot read properties of undefined (reading 'id')\n    at /usr/src/app/bundle.js:295678:58\n    at Array.map (<anonymous>)\n    at IssueSyncManager.externalSync (/usr/src/app/bundle.js:295678:34)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)"},"level":"error","message":"Error","timestamp":"2026-02-11T13:58:29.069Z"}
{"action":"synchronize","level":"info","login":"tofijak","message":"pull request:handleEvent","nodeId":"https://github.com/Serpier/serpier/pull/718","timestamp":"2026-02-11T13:58:29.415Z","type":"User","workspace":"1f909283-5af7-4b56-b948-3d3cc141c9fb"}
{"action":"synchronize","id":"bda77610-0751-11f1-9d87-e9a5874f73d5","level":"info","message":"webhook event","name":"pull_request","timestamp":"2026-02-11T13:58:29.415Z"}
{"docs":14,"field":"externalVersion","level":"info","message":"External Syncing","name":"maxint-web","prj":"web","timestamp":"2026-02-11T13:58:29.550Z","version":"v4","workspace":"612a9d74-ad04-4a74-81d2-188e88cb351e"}
{"err":{"message":"Cannot read properties of undefined (reading 'id')","stack":"TypeError: Cannot read properties of undefined (reading 'id')\n    at /usr/src/app/bundle.js:295678:58\n    at Array.map (<anonymous>)\n    at IssueSyncManager.externalSync (/usr/src/app/bundle.js:295678:34)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)"},"level":"error","message":"Error","timestamp":"2026-02-11T13:58:29.551Z"}
{"docs":14,"field":"externalVersion","level":"info","message":"External Syncing","name":"maxint-web","prj":"web","timestamp":"2026-02-11T13:58:29.915Z","version":"v4","workspace":"612a9d74-ad04-4a74-81d2-188e88cb351e"}
{"err":{"message":"Cannot read properties of undefined (reading 'id')","stack":"TypeError: Cannot read properties of undefined (reading 'id')\n    at /usr/src/app/bundle.js:295678:58\n    at Array.map (<anonymous>)\n    at IssueSyncManager.externalSync (/usr/src/app/bundle.js:295678:34)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)"},"level":"error","message":"Error","timestamp":"2026-02-11T13:58:29.915Z"}
```