### PR TITLE
Support browser translations for read only editor

### DIFF
--- a/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
@@ -425,7 +425,10 @@
       element,
       editable: !readonly,
       editorProps: {
-        attributes: mergeAttributes(defaultEditorAttributes, editorAttributes, { class: 'flex-grow' })
+        attributes: mergeAttributes(defaultEditorAttributes, editorAttributes, {
+          class: 'flex-grow',
+          translate: readonly ? 'yes' : 'no'
+        })
       },
       enableContentCheck: true,
       parseOptions: {


### PR DESCRIPTION
<img width="1440" height="465" src="https://github.com/user-attachments/assets/c6587526-2b11-42a0-9e7f-292a4d706bb6" alt="Screenshot 2026-02-11 at 22 13 19">
