### PR TITLE
Fix: password signup shows JSON parse error when MAIL_URL is configured

### DIFF
--- a/plugins/login-resources/src/__tests__/signupTokenGuard.test.ts
+++ b/plugins/login-resources/src/__tests__/signupTokenGuard.test.ts
@@ -1,0 +1,97 @@
+// Copyright © 2025 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Tests for the token guard fix in SignupForm.svelte (issue #10518).
+ *
+ * When MAIL_URL is configured the account service returns token: undefined
+ * to force email confirmation. The signup handler must skip logIn() in that
+ * case — calling logIn() without a token triggers PUT /cookie with no
+ * Authorization header, which returns 401 and crashes the client's JSON
+ * parser with "Unexpected token".
+ */
+
+interface LoginInfo {
+  account: string
+  name?: string
+  token?: string
+}
+
+/**
+ * Mirrors the fixed logic from SignupForm.svelte:
+ *
+ *   if (result != null) {
+ *     if (result.token != null) {
+ *       await logIn(result)
+ *     }
+ *     goTo('confirmationSend')
+ *   }
+ */
+async function handleSignupResult (
+  result: LoginInfo | null,
+  logIn: (info: LoginInfo) => Promise<void>,
+  goTo: (page: string) => void
+): Promise<void> {
+  if (result != null) {
+    if (result.token != null) {
+      await logIn(result)
+    }
+    goTo('confirmationSend')
+  }
+}
+
+describe('SignupForm token guard (issue #10518)', () => {
+  let logIn: jest.Mock
+  let goTo: jest.Mock
+
+  beforeEach(() => {
+    logIn = jest.fn().mockResolvedValue(undefined)
+    goTo = jest.fn()
+  })
+
+  it('skips logIn and redirects to confirmationSend when token is undefined (MAIL_URL configured)', async () => {
+    // Server returns token: undefined when email confirmation is required
+    const result: LoginInfo = { account: 'acc-uuid', name: 'Alice Smith', token: undefined }
+
+    await handleSignupResult(result, logIn, goTo)
+
+    expect(logIn).not.toHaveBeenCalled()
+    expect(goTo).toHaveBeenCalledWith('confirmationSend')
+  })
+
+  it('skips logIn and redirects to confirmationSend when token is absent', async () => {
+    const result: LoginInfo = { account: 'acc-uuid' }
+
+    await handleSignupResult(result, logIn, goTo)
+
+    expect(logIn).not.toHaveBeenCalled()
+    expect(goTo).toHaveBeenCalledWith('confirmationSend')
+  })
+
+  it('calls logIn then redirects to confirmationSend when token is present (no MAIL_URL)', async () => {
+    const result: LoginInfo = { account: 'acc-uuid', name: 'Bob Jones', token: 'eyJhbGciOiJIUzI1NiJ9.test' }
+
+    await handleSignupResult(result, logIn, goTo)
+
+    expect(logIn).toHaveBeenCalledTimes(1)
+    expect(logIn).toHaveBeenCalledWith(result)
+    expect(goTo).toHaveBeenCalledWith('confirmationSend')
+  })
+
+  it('calls neither logIn nor goTo when result is null (signup error)', async () => {
+    await handleSignupResult(null, logIn, goTo)
+
+    expect(logIn).not.toHaveBeenCalled()
+    expect(goTo).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/login-resources/src/components/SignupForm.svelte
+++ b/plugins/login-resources/src/components/SignupForm.svelte
@@ -95,7 +95,9 @@
         status = loginStatus
 
         if (result != null) {
-          await logIn(result)
+          if (result.token != null) {
+            await logIn(result)
+          }
           goTo('confirmationSend')
         }
       }

--- a/server/account-service/src/index.ts
+++ b/server/account-service/src/index.ts
@@ -306,11 +306,8 @@ export function serveAccount (measureCtx: MeasureContext, brandings: BrandingMap
   router.put('/cookie', async (ctx) => {
     const token = extractToken(ctx.request.headers)
     if (token === undefined) {
-      ctx.body = JSON.stringify({
-        error: new Status(Severity.ERROR, platform.status.Unauthorized, {})
-      })
-      ctx.res.writeHead(401)
-      ctx.res.end()
+      ctx.status = 401
+      ctx.body = { error: new Status(Severity.ERROR, platform.status.Unauthorized, {}) }
       return
     }
 


### PR DESCRIPTION
## Summary

Fixes #10518

When signing up with a password on deployments where `MAIL_URL` is configured, the account service returns `token: undefined` to enforce email confirmation. `SignupForm.svelte` was calling `logIn()` unconditionally — this triggered `PUT /cookie` with no `Authorization` header, the server returned 401 with an unparseable body, and the client crashed with _"Unknown error: Unexpected token"_, leaving users stuck on the signup page even though their account was created successfully.

- **`SignupForm.svelte`**: guard `logIn()` with `result.token != null`, matching the pattern already used in `doLoginNavigate()` in `utils.ts`
- **`server/account-service/src/index.ts`**: fix `PUT /cookie` 401 response to use Koa's `ctx.status`/`ctx.body` instead of raw `ctx.res.writeHead()`/`ctx.res.end()`, so the JSON error body is correctly serialized
- **`signupTokenGuard.test.ts`**: unit tests covering the token guard logic for all cases (undefined token, absent token, present token, null result)

## Test plan

- [ ] Deploy with `MAIL_URL` set to a real or dummy SMTP URL
- [ ] Sign up with password ("Set Password Now") — should redirect to confirmation-sent page, no error
- [ ] Verify `PUT /cookie` is not called in the network tab (token is undefined, so `logIn()` is skipped)
- [ ] Deploy without `MAIL_URL` — sign up with password should still call `logIn()` and proceed to workspace selection as before
- [ ] `curl -X PUT http://localhost:3000/cookie` → should return valid JSON `{"error":{...}}` with HTTP 401