### PR TITLE
Fix: images not rendering on GitHub side of GitHub integration

### DIFF
--- a/services/github/pod-github/src/worker.ts
+++ b/services/github/pod-github/src/worker.ts
@@ -244,7 +244,10 @@ export class GithubWorker implements IntegrationManager {
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/browse/?workspace=${this.workspace.uuid}`),
       // TODO storage URL
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/files/${this.workspace.uuid}/`),
-      preprocessor ?? (async (nodes) => { appendGuestLinkToImage(nodes, this.workspace.uuid) })
+      preprocessor ??
+        (async (nodes) => {
+          appendGuestLinkToImage(nodes, this.workspace.uuid)
+        })
     )
   }
 

--- a/services/github/pod-github/src/worker.ts
+++ b/services/github/pod-github/src/worker.ts
@@ -85,6 +85,7 @@ import { RepositorySyncMapper } from './sync/repository'
 import { ReviewCommentSyncManager } from './sync/reviewComments'
 import { ReviewThreadSyncManager } from './sync/reviewThreads'
 import { ReviewSyncManager } from './sync/reviews'
+import { appendGuestLinkToImage } from './sync/guest'
 import { UsersSyncManager, fetchViewerDetails } from './sync/users'
 import { errorToObj } from './sync/utils'
 import {
@@ -243,7 +244,7 @@ export class GithubWorker implements IntegrationManager {
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/browse/?workspace=${this.workspace.uuid}`),
       // TODO storage URL
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/files/${this.workspace.uuid}/`),
-      preprocessor
+      preprocessor ?? (async (nodes) => { appendGuestLinkToImage(nodes, this.workspace.uuid) })
     )
   }
 


### PR DESCRIPTION
## Summary

Fixes #10516

The infrastructure to fix this already existed but was never wired in. When Huly syncs content to GitHub, `getMarkdown()` in `worker.ts` converts Huly markup to GitHub-flavored markdown. Images produce URLs that require authentication, so GitHub's Camo proxy fails to fetch them.

- `appendGuestLinkToImage` in `sync/guest.ts` stamps a guest JWT token onto image markup nodes
- `markupToMarkdown` in `markdown/index.ts` accepts a `preprocessor` callback and invokes it on the AST before serialization  
- The serializer in `text-markdown` already appends `&token=` to the URL when `attrs.token` is present

The gap: none of the `getMarkdown()` call sites passed a preprocessor. This PR wires `appendGuestLinkToImage` as the **default preprocessor** in `getMarkdown()` itself, so all 7 call sites (issues, comments, issueBase) automatically emit token-stamped image URLs without any per-call-site changes.

## Changes

- `services/github/pod-github/src/worker.ts`: import `appendGuestLinkToImage` and use it as the default `preprocessor` in `getMarkdown()`

## Test plan

- [ ] Create a GitHub-connected Huly issue with an image in the description
- [ ] Verify the image renders on the GitHub issue page (not broken)
- [ ] Create a comment with an image attachment and verify same on GitHub
- [ ] Verify existing text-only sync is unaffected