### PR TITLE
fix(love): use addCollection/createTxCollectionCUD for MeetingMinutes creation

### DIFF
--- a/models/love/src/index.ts
+++ b/models/love/src/index.ts
@@ -180,7 +180,7 @@ export class TMeeting extends TEvent implements Meeting {
   room!: Ref<Room>
 }
 
-@Model(love.class.MeetingMinutes, core.class.Doc, DOMAIN_MEETING_MINUTES)
+@Model(love.class.MeetingMinutes, core.class.AttachedDoc, DOMAIN_MEETING_MINUTES)
 @UX(
   love.string.MeetingMinutes,
   love.icon.MeetingMinutes,

--- a/plugins/love-resources/src/meetings.ts
+++ b/plugins/love-resources/src/meetings.ts
@@ -172,13 +172,10 @@ async function moveToMeetingRoom (room: Room): Promise<void> {
 
 async function createMeetingDocument (room: Room): Promise<void> {
   const client = getClient()
-  await client.createDoc(love.class.MeetingMinutes, core.space.Workspace, {
+  await client.addCollection(love.class.MeetingMinutes, core.space.Workspace, room._id, love.class.Room, 'meetings', {
     description: null,
-    attachedTo: room._id,
     status: MeetingStatus.Active,
-    title: await getNewMeetingTitle(room),
-    attachedToClass: love.class.Room,
-    collection: 'meetings'
+    title: await getNewMeetingTitle(room)
   })
 }
 

--- a/server-plugins/love-resources/src/index.ts
+++ b/server-plugins/love-resources/src/index.ts
@@ -225,7 +225,7 @@ async function roomJoinHandler (info: ParticipantInfo, control: TriggerControl):
           year: 'numeric'
         })
         .replace(',', ' at')
-      const tx = control.txFactory.createTxCreateDoc(
+      const innerTx = control.txFactory.createTxCreateDoc(
         love.class.MeetingMinutes,
         core.space.Workspace,
         {
@@ -237,6 +237,13 @@ async function roomJoinHandler (info: ParticipantInfo, control: TriggerControl):
           collection: 'meetings'
         },
         _id
+      )
+      const tx = control.txFactory.createTxCollectionCUD(
+        love.class.Room,
+        info.room,
+        core.space.Workspace,
+        'meetings',
+        innerTx
       )
       tx.space = core.space.Tx
       res.push(tx)


### PR DESCRIPTION
## Summary

Fixes #10526. Also related to #8785 and #7303.

After a meeting ends the Room detail view always showed **"No meeting minutes"** even when MeetingMinutes documents existed in the database. The `MeetingMinutesSection.svelte` component gates rendering on `meetings > 0`, but that counter was never incremented because MeetingMinutes were created with `createDoc`/`createTxCreateDoc` instead of `addCollection`/`createTxCollectionCUD`.

The collection counter trigger in `server/middleware/triggers.ts` (`processCollection`) only fires when `attachedTo`, `attachedToClass`, and `collection` are **top-level transaction properties** — which only `TxCollectionCUD` provides. `createDoc` / `createTxCreateDoc` puts those fields inside `attributes` (the document data), so the trigger never fires and the Room counter stays at 0.

## Changes

- **`models/love/src/index.ts`** — change `@Model` parent from `core.class.Doc` → `core.class.AttachedDoc` so `hierarchy.isDerived(love.class.MeetingMinutes, core.class.AttachedDoc)` returns `true`
- **`plugins/love-resources/src/meetings.ts`** — replace `client.createDoc(...)` with `client.addCollection(...)` for client-side MeetingMinutes creation
- **`server-plugins/love-resources/src/index.ts`** — wrap the `createTxCreateDoc` in a `createTxCollectionCUD` so the server-side trigger correctly increments the Room's `meetings` counter

## Test plan

- [ ] Start a meeting in a Room, enable transcription, speak for 30+ seconds, then end the meeting
- [ ] Room detail page → "Meeting minutes" section shows the meeting (not "No meeting minutes")
- [ ] `meetings` counter on the Room document increments correctly after each meeting
- [ ] Existing MeetingMinutes documents and transcription data are unaffected
- [ ] Office rooms still create MeetingMinutes correctly
- [ ] Collaborators are still attached to newly created MeetingMinutes

## Workaround for existing deployments

For self-hosted CockroachDB deployments where the counter is already stuck at 0, run:

```sql
UPDATE love
SET data = jsonb_set(COALESCE(data, '{}'::jsonb), '{meetings}', (
    SELECT COALESCE(to_jsonb(count(*)), '0'::jsonb)
    FROM meeting_minutes
    WHERE "attachedTo" = love._id
    AND "workspaceId" = love."workspaceId"
)::jsonb)
WHERE _class IN ('love:class:Room', 'love:class:Office');
```