### PR TITLE
feat(love): enable transcription language selector and restore Deepgram language support

### DIFF
--- a/plugins/love-resources/src/components/AddRoomPopup.svelte
+++ b/plugins/love-resources/src/components/AddRoomPopup.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import core, { Class, Data, generateId, type Doc, Ref } from '@hcengineering/core'
-  import { Floor, getFreePosition, Office, Room, RoomAccess, RoomType } from '@hcengineering/love'
+  import { Floor, getFreePosition, Office, Room, RoomAccess, RoomLanguage, RoomType } from '@hcengineering/love'
   import { translate } from '@hcengineering/platform'
   import { getClient } from '@hcengineering/presentation'
   import setting, { type OfficeSettings } from '@hcengineering/setting'
@@ -8,6 +8,14 @@
   import { createEventDispatcher } from 'svelte'
   import love from '../plugin'
   import { rooms, selectedFloor } from '../stores'
+  import { languagesDisplayData } from '../types'
+
+  function getDefaultLanguage (): RoomLanguage {
+    const locale = navigator.language
+    if (locale in languagesDisplayData) return locale as RoomLanguage
+    const lang = locale.split('-')[0]
+    return (lang in languagesDisplayData ? lang : 'en') as RoomLanguage
+  }
 
   export let floor: Ref<Floor>
 
@@ -73,7 +81,7 @@
       height: 1,
       type: val.type,
       access: val.access,
-      language: 'en',
+      language: getDefaultLanguage(),
       startWithTranscription: defaultTranscription,
       startWithRecording: defaultRecording,
       description: null

--- a/plugins/love-resources/src/components/RoomTranscriptionSettings.svelte
+++ b/plugins/love-resources/src/components/RoomTranscriptionSettings.svelte
@@ -13,9 +13,10 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { Label, ModernToggle } from '@hcengineering/ui'
+  import ui, { Label, ModernToggle } from '@hcengineering/ui'
   import love, { Room } from '@hcengineering/love'
   import { getClient } from '@hcengineering/presentation'
+  import RoomLanguageSelector from './RoomLanguageSelector.svelte'
 
   export let room: Room
 
@@ -31,12 +32,12 @@
 </script>
 
 <div class="antiGrid">
-  <!-- <div class="antiGrid-row">
+  <div class="antiGrid-row">
     <div class="antiGrid-row__header">
       <Label label={ui.string.Language} />
     </div>
     <RoomLanguageSelector {room} />
-  </div> -->
+  </div>
   <div class="antiGrid-row">
     <div class="antiGrid-row__header">
       <Label label={love.string.StartWithTranscription} />

--- a/services/ai-bot/love-agent/src/deepgram/stt.ts
+++ b/services/ai-bot/love-agent/src/deepgram/stt.ts
@@ -33,7 +33,7 @@ export class STT implements Stt {
   private readonly deepgram: DeepgramClient
 
   private isInProgress = false
-  // private language: string = 'en'
+  private language: string = 'multi'
 
   private readonly trackBySid = new Map<string, RemoteTrack>()
   private readonly streamBySid = new Map<string, AudioStream>()
@@ -52,12 +52,12 @@ export class STT implements Stt {
   }
 
   updateLanguage (language: string): void {
-    // const shouldRestart = (this.language ?? 'en') !== language
-    // this.language = language
-    // if (shouldRestart) {
-    //   this.stop()
-    //   this.start()
-    // }
+    const shouldRestart = this.language !== language
+    this.language = language
+    if (shouldRestart) {
+      this.stop()
+      this.start()
+    }
   }
 
   start (): void {
@@ -161,7 +161,7 @@ export class STT implements Stt {
       encoding: 'linear16',
       channels: stream.numChannels,
       sample_rate: stream.sampleRate,
-      language: 'multi',
+      language: this.language,
       model: config.DeepgramModel
     }
   }
@@ -172,7 +172,6 @@ export class STT implements Stt {
     if (this.dgConnectionBySid.has(sid)) return
 
     const stream = new AudioStream(track, config.DgSampleRate)
-    // const language = this.language ?? 'en'
     const options = this.getOptions(stream)
     const dgConnection = this.deepgram.listen.live(options)
     console.log('Starting deepgram for track', this.room.name, sid, options)


### PR DESCRIPTION
## Summary

Fixes #10532.

The `RoomLanguageSelector` component was **fully built** (45 languages, flag emojis, live update via `client.diffUpdate`) but commented out in `RoomTranscriptionSettings.svelte`, so every room defaulted to English with no way to change it from the UI. OpenAI STT users in non-English environments received garbled output with ~30% confidence scores.

## Changes

### `plugins/love-resources/src/components/RoomTranscriptionSettings.svelte`
- Uncomment the language selector `antiGrid-row` that was blocked behind `<!-- ... -->`
- Add missing imports: `ui` (plugin reference, for `ui.string.Language`) and `RoomLanguageSelector`

### `plugins/love-resources/src/components/AddRoomPopup.svelte`
- Replace hardcoded `language: 'en'` with `getDefaultLanguage()` which reads `navigator.language`
- Checks full locale first (`zh-TW`, `en-GB`, …), falls back to base language (`zh`, `en`, …), then to `'en'` if not in the supported list

### `services/ai-bot/love-agent/src/deepgram/stt.ts`
- Restore `private language: string = 'multi'` (default preserves existing Nova-3 auto-detect behaviour)
- Uncomment the `updateLanguage()` stop/restart implementation so language changes propagate to active connections
- Wire `this.language` through `getOptions()` instead of hardcoded `'multi'`
- Remove the now-redundant commented-out local variable in `processTrack`

## Behaviour after this change

| Scenario | Before | After |
|----------|--------|-------|
| Room language setting visible | ❌ Hidden | ✅ Shown in transcription settings |
| New room language default | Always `'en'` | Browser locale (fallback `'en'`) |
| OpenAI STT language | Always `'en'` → garbled for non-English | Follows room language setting |
| Deepgram STT language | Always `'multi'` (hardcoded) | `'multi'` by default; follows room language if changed |
| Mid-meeting language change (Deepgram) | No-op | Restarts connections with new language |

## Test plan

- [ ] Open a Room's transcription settings — language selector row is visible
- [ ] Change language in settings — selector persists after page refresh
- [ ] Start a meeting in a non-English room with OpenAI STT — transcriptions are in the correct language
- [ ] Create a new room from a non-English browser locale — room defaults to that locale
- [ ] Deepgram: change room language mid-meeting — connections restart and use new language
- [ ] Deepgram: leaving language at default — `'multi'` auto-detect is unchanged