### PR TITLE
fix(account): handle empty $in array to prevent PostgreSQL IN () syntax error

### DIFF
--- a/server/account/src/collections/postgres/postgres.ts
+++ b/server/account/src/collections/postgres/postgres.ts
@@ -176,6 +176,10 @@ implements DbCollection<T> {
       switch (operator) {
         case '$in': {
           const inVals = Object.values(qKey as object)[0]
+          if (inVals.length === 0) {
+            whereChunks.push('FALSE')
+            break
+          }
           const inVars: string[] = []
           for (const val of inVals) {
             currIdx++

--- a/server/account/src/utils.ts
+++ b/server/account/src/utils.ts
@@ -1351,6 +1351,7 @@ export async function getWorkspacesInfoWithStatusByIds (
   db: AccountDB,
   uuids: WorkspaceUuid[]
 ): Promise<WorkspaceInfoWithStatus[]> {
+  if (uuids.length === 0) return []
   const statuses = await db.workspaceStatus.find({ workspaceUuid: { $in: uuids } })
   const statusesMap = statuses.reduce<Record<string, WorkspaceStatus>>((sm, s) => {
     sm[s.workspaceUuid] = s

--- a/server/account/src/utils.ts
+++ b/server/account/src/utils.ts
@@ -1351,7 +1351,7 @@ export async function getWorkspacesInfoWithStatusByIds (
   db: AccountDB,
   uuids: WorkspaceUuid[]
 ): Promise<WorkspaceInfoWithStatus[]> {
-  if (uuids.length === 0) return []
+  if (!Array.isArray(uuids) || uuids.length === 0) return []
   const statuses = await db.workspaceStatus.find({ workspaceUuid: { $in: uuids } })
   const statusesMap = statuses.reduce<Record<string, WorkspaceStatus>>((sm, s) => {
     sm[s.workspaceUuid] = s


### PR DESCRIPTION
## Summary

- In `buildWhereClause` (`postgres.ts`), emit `FALSE` when a `$in` array is empty instead of generating invalid `IN ()` SQL that PostgreSQL rejects with a syntax error.
- In `getWorkspacesInfoWithStatusByIds` (`utils.ts`), add an early `return []` when `uuids` is empty so callers (GitHub, Gmail, Backup services) never reach the query with an empty list.

Fixes #10553

## Test plan

- [ ] Self-host on PostgreSQL with the GitHub integration configured but no repos connected — confirm the `IN ()` error no longer appears in account logs every ~6 minutes.
- [ ] Verify `getWorkspacesInfo` returns `[]` when called with an empty id array instead of throwing a PostgreSQL syntax error.
- [ ] Verify existing workspace-lookup behaviour is unchanged when a non-empty id array is provided.