### PR TITLE
Fix import tool launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -941,14 +941,14 @@
         "/home/anna/work/notion/natalya/Export-fad9ecb4-a1a5-4623-920d-df32dd423743",
         "-u",
         "user1",
-        "-pw",
+        "-p",
         "1234",
-        "-ws",
+        "-w",
         "ws5",
-        "-ts",
+        "-t",
         "notion"
       ],
-      // "args": ["src/__start.ts", "import-notion-with-teamspaces", "/home/anna/work/notion/natalya/Export-fad9ecb4-a1a5-4623-920d-df32dd423743", "-u", "user1", "-pw", "1234", "-ws", "ws1"],
+      // "args": ["src/__start.ts", "import-notion-with-teamspaces", "/home/anna/work/notion/natalya/Export-fad9ecb4-a1a5-4623-920d-df32dd423743", "-u", "user1", "-p", "1234", "-w", "ws1"],
       "env": {
         "FRONT_URL": "http://localhost:8087"
       },
@@ -968,9 +968,9 @@
         "/home/anna/work/clickup/aleksandr/debug/mentions.csv",
         "-u",
         "user1",
-        "-pw",
+        "-p",
         "1234",
-        "-ws",
+        "-w",
         "ws10"
       ],
       "env": {
@@ -992,9 +992,9 @@
         "/home/anna/huly/platform/dev/import-tool/docs/huly/example-workspace",
         "-u",
         "user1",
-        "-pw",
+        "-p",
         "1234",
-        "-ws",
+        "-w",
         "ws1"
       ],
       "env": {

--- a/dev/import-tool/src/index.ts
+++ b/dev/import-tool/src/index.ts
@@ -115,8 +115,8 @@ export function importTool (): void {
     .command('import-notion-with-teamspaces <dir>')
     .description('import extracted archive exported from Notion as "Markdown & CSV"')
     .requiredOption('-u, --user <user>', 'user')
-    .requiredOption('-pw, --password <password>', 'password')
-    .requiredOption('-ws, --workspace <workspace>', 'workspace url where the documents should be imported to')
+    .requiredOption('-p, --password <password>', 'password')
+    .requiredOption('-w, --workspace <workspace>', 'workspace url where the documents should be imported to')
     .action(async (dir: string, cmd) => {
       const { workspace, user, password } = cmd
       await authorize(user, password, workspace, async (client, uploader) => {
@@ -129,9 +129,9 @@ export function importTool (): void {
     .command('import-notion-to-teamspace <dir>')
     .description('import extracted archive exported from Notion as "Markdown & CSV"')
     .requiredOption('-u, --user <user>', 'user')
-    .requiredOption('-pw, --password <password>', 'password')
-    .requiredOption('-ws, --workspace <workspace>', 'workspace url where the documents should be imported to')
-    .requiredOption('-ts, --teamspace <teamspace>', 'new teamspace name where the documents should be imported to')
+    .requiredOption('-p, --password <password>', 'password')
+    .requiredOption('-w, --workspace <workspace>', 'workspace url where the documents should be imported to')
+    .requiredOption('-t, --teamspace <teamspace>', 'new teamspace name where the documents should be imported to')
     .action(async (dir: string, cmd) => {
       const { workspace, user, password, teamspace } = cmd
       await authorize(user, password, workspace, async (client, uploader) => {
@@ -144,8 +144,8 @@ export function importTool (): void {
     .command('import-clickup-tasks <file>')
     .description('import extracted archive exported from Notion as "Markdown & CSV"')
     .requiredOption('-u, --user <user>', 'user')
-    .requiredOption('-pw, --password <password>', 'password')
-    .requiredOption('-ws, --workspace <workspace>', 'workspace url where the documents should be imported to')
+    .requiredOption('-p, --password <password>', 'password')
+    .requiredOption('-w, --workspace <workspace>', 'workspace url where the documents should be imported to')
     .action(async (file: string, cmd) => {
       const { workspace, user, password } = cmd
       await authorize(user, password, workspace, async (client, uploader) => {
@@ -159,8 +159,8 @@ export function importTool (): void {
     .command('import <dir>')
     .description('import issues in Unified Huly Format')
     .requiredOption('-u, --user <user>', 'user')
-    .requiredOption('-pw, --password <password>', 'password')
-    .requiredOption('-ws, --workspace <workspace>', 'workspace url where the documents should be imported to')
+    .requiredOption('-p, --password <password>', 'password')
+    .requiredOption('-w, --workspace <workspace>', 'workspace url where the documents should be imported to')
     .action(async (dir: string, cmd) => {
       const { workspace, user, password } = cmd
       await authorize(user, password, workspace, async (client, uploader) => {

--- a/foundations/utils/.vscode/launch.json
+++ b/foundations/utils/.vscode/launch.json
@@ -890,14 +890,14 @@
         "/home/anna/work/notion/natalya/Export-fad9ecb4-a1a5-4623-920d-df32dd423743",
         "-u",
         "user1",
-        "-pw",
+        "-p",
         "1234",
-        "-ws",
+        "-w",
         "ws5",
-        "-ts",
+        "-t",
         "notion"
       ],
-      // "args": ["src/__start.ts", "import-notion-with-teamspaces", "/home/anna/work/notion/natalya/Export-fad9ecb4-a1a5-4623-920d-df32dd423743", "-u", "user1", "-pw", "1234", "-ws", "ws1"],
+      // "args": ["src/__start.ts", "import-notion-with-teamspaces", "/home/anna/work/notion/natalya/Export-fad9ecb4-a1a5-4623-920d-df32dd423743", "-u", "user1", "-p", "1234", "-w", "ws1"],
       "env": {
         "FRONT_URL": "http://localhost:8087"
       },
@@ -917,9 +917,9 @@
         "/home/anna/work/clickup/aleksandr/debug/mentions.csv",
         "-u",
         "user1",
-        "-pw",
+        "-p",
         "1234",
-        "-ws",
+        "-w",
         "ws10"
       ],
       "env": {
@@ -941,9 +941,9 @@
         "/home/anna/huly/platform/dev/import-tool/docs/huly/example-workspace",
         "-u",
         "user1",
-        "-pw",
+        "-p",
         "1234",
-        "-ws",
+        "-w",
         "ws1"
       ],
       "env": {


### PR DESCRIPTION
Import tool cannot be launched due to error:

```
Error: option creation failed due to '-pw' in option flags '-pw, --password <password>'
- a short flag is a single dash and a single character
  - either use a single dash and a single character (for a short flag)
  - or use a double dash for a long option (and can have two, like '--ws, --workspace')
    at splitOptionFlags (/usr/src/app/bundle.js:110228:17)
    at new Option (/usr/src/app/bundle.js:109955:29)
```