### PR TITLE
fix(tracker): make Project.defaultIssueStatus optional

### DIFF
--- a/models/tracker/src/migration.ts
+++ b/models/tracker/src/migration.ts
@@ -200,10 +200,12 @@ async function migrateDefaultStatuses (client: MigrationClient, logger: ModelLog
     // 1. defaultIssueStatus
     // 2. DocUpdateMessage:update:defaultIssueStatus
     for (const project of projects) {
-      const newDefaultIssueStatus = getNewStatus(project.defaultIssueStatus)
+      if (project.defaultIssueStatus != null) {
+        const newDefaultIssueStatus = getNewStatus(project.defaultIssueStatus)
 
-      if (project.defaultIssueStatus !== newDefaultIssueStatus) {
-        await client.update(DOMAIN_SPACE, { _id: project._id }, { defaultIssueStatus: newDefaultIssueStatus })
+        if (project.defaultIssueStatus !== newDefaultIssueStatus) {
+          await client.update(DOMAIN_SPACE, { _id: project._id }, { defaultIssueStatus: newDefaultIssueStatus })
+        }
       }
 
       const projectUpdateMessages = await client.find<DocUpdateMessage>(DOMAIN_ACTIVITY, {

--- a/models/tracker/src/types.ts
+++ b/models/tracker/src/types.ts
@@ -126,7 +126,7 @@ export class TProject extends TTaskProject implements Project {
     sequence!: number
 
   @Prop(TypeRef(tracker.class.IssueStatus), tracker.string.DefaultIssueStatus)
-    defaultIssueStatus!: Ref<IssueStatus>
+    defaultIssueStatus?: Ref<IssueStatus>
 
   @Prop(TypeRef(contact.mixin.Employee), tracker.string.DefaultAssignee)
     defaultAssignee!: Ref<Employee>

--- a/plugins/tracker/src/index.ts
+++ b/plugins/tracker/src/index.ts
@@ -61,7 +61,7 @@ export interface IssueStatus extends Status {}
 export interface Project extends TaskProject, IconProps {
   identifier: string // Project identifier
   sequence: number
-  defaultIssueStatus: Ref<IssueStatus>
+  defaultIssueStatus?: Ref<IssueStatus>
   defaultAssignee?: Ref<Employee>
   defaultTimeReportDay: TimeReportDayType
 }


### PR DESCRIPTION
fixes https://github.com/hcengineering/platform/issues/10597

The field is undefined at runtime for projects created without an explicit default status (e.g. workspace templates, CreateProject UI with no selection). The platform's own StatusEditor already handles this by falling back to statuses[0]. Making the type honest about the runtime reality surfaces latent bugs at compile time.

Call sites that may need updating:

  - [`SubIssues.svelte:51,79`](https://github.com/hcengineering/platform/blob/e8c0f8ef4dcf5394501ae2f8182ca27bb14b2d5f/plugins/tracker-resources/src/components/SubIssues.svelte#L51-L79)
  - [`DraftIssueChildEditor.svelte:72,87`](https://github.com/hcengineering/platform/blob/e8c0f8ef4dcf5394501ae2f8182ca27bb14b2d5f/plugins/tracker-resources/src/components/templates/DraftIssueChildEditor.svelte#L72-L87)
  - [`migration.ts:203`](https://github.com/dearlordylord/hulysdk-platform/blob/fix/optional-defaultIssueStatus/models/tracker/src/migration.ts#L203)
  - [`CreateVacancy.svelte:188`](https://github.com/hcengineering/platform/blob/e8c0f8ef4dcf5394501ae2f8182ca27bb14b2d5f/plugins/recruit-resources/src/components/CreateVacancy.svelte#L188)

# side effects

to keep it compilable, had to change

migration.ts

This migration remaps old status refs to new status refs. If defaultIssueStatus is undefined, there is no ref to remap, the guard skips a no-op. The DocUpdateMessage activity migration still runs unconditionally for every project, so historical audit records are still migrated even for projects with no current defaultIssueStatus.

## Tested on

Huly v0.7.353 (self-hosted), REST API via `@hcengineering/api-client`.