### PR TITLE
Fix express misconfiguration in payment service

### DIFF
--- a/services/payment/pod-payment/src/server.ts
+++ b/services/payment/pod-payment/src/server.ts
@@ -76,6 +76,7 @@ const handleRequest = async (
 
 export async function createServer (ctx: MeasureContext, config: Config): Promise<{ app: Express, close: () => void }> {
   const app = express()
+  app.set('trust proxy', true)
   app.use(cors())
 
   const childLogger = ctx.logger.childLogger?.('requests', { enableConsole: 'true' })


### PR DESCRIPTION
Fix express misconfiguration:

```
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default). This could indicate a misconfiguration which would prevent express-rate-limit from accurately identifying users. See https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/ for more information.
    at Object.xForwardedForHeader (/app/bundle.js:160015:13)
    at wrappedValidations.<computed> [as xForwardedForHeader] (/app/bundle.js:160227:22)
    at Object.keyGenerator (/app/bundle.js:160476:20)
    at /app/bundle.js:160528:33
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async /app/bundle.js:160509:5 {
  code: 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR',
  help: 'https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/'
}
```