### PR TITLE
feat(notification-resources): improve inbox list keyboard navigation and a11y

### DIFF
--- a/plugins/notification-resources/src/components/inbox/InboxGroupedListView.svelte
+++ b/plugins/notification-resources/src/components/inbox/InboxGroupedListView.svelte
@@ -110,14 +110,24 @@
     if (key.code === 'ArrowUp') {
       key.stopPropagation()
       key.preventDefault()
-      list.select(listSelection - 1)
+      selectIndex(listSelection - 1)
     }
     if (key.code === 'ArrowDown') {
       key.stopPropagation()
       key.preventDefault()
-      list.select(listSelection + 1)
+      selectIndex(listSelection + 1)
     }
-    if (key.code === 'Backspace') {
+    if (key.code === 'Home') {
+      key.stopPropagation()
+      key.preventDefault()
+      selectIndex(0)
+    }
+    if (key.code === 'End') {
+      key.stopPropagation()
+      key.preventDefault()
+      selectIndex(displayData.length - 1)
+    }
+    if (key.code === 'Backspace' || key.code === 'Delete') {
       key.preventDefault()
       key.stopPropagation()
 
@@ -141,11 +151,22 @@
     const contextId = displayData[index][0]
     return contextId ?? index.toString()
   }
+
+  function selectIndex (index: number): void {
+    if (displayData.length === 0) return
+
+    list.select(Math.max(0, Math.min(index, displayData.length - 1)))
+  }
 </script>
 
-<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
-<div class="root" bind:this={element} tabindex="0" on:keydown={onKeydown}>
+<div
+  class="root"
+  bind:this={element}
+  tabindex="0"
+  role="listbox"
+  aria-label="Inbox notifications"
+  on:keydown={onKeydown}
+>
   <ListView
     bind:this={list}
     bind:selection={listSelection}


### PR DESCRIPTION
## Summary

Improve keyboard usability and accessibility semantics in the inbox grouped list view.

## Changes

- Added keyboard shortcuts in inbox list:
  - `Home` -> jump to first item
  - `End` -> jump to last item
  - `Delete` -> archive/unarchive selected context (same behavior as existing `Backspace`)
- Kept existing behavior for `ArrowUp`, `ArrowDown`, and `Enter`.
- Added a bounded `selectIndex` helper to avoid out-of-range selections.
- Replaced a11y suppressions with explicit semantics on the focusable container:
  - `role="listbox"`
  - `aria-label="Inbox notifications"`

## Files

- `plugins/notification-resources/src/components/inbox/InboxGroupedListView.svelte`

## Why

This makes list navigation faster for keyboard users and improves assistive-technology interpretation of the interactive list container.

## Testing

- Open Inbox and focus grouped list.
- Verify:
  - `ArrowUp/ArrowDown` moves selection
  - `Home/End` jumps to first/last context
  - `Enter` opens selected context
  - `Backspace/Delete` archives selected context
- Confirm no behavior change in mouse interactions.