### PR TITLE
feat(communication-resources): improve messages loading state accessibility

### DIFF
--- a/plugins/communication-resources/src/components/message/MessagesLoading.svelte
+++ b/plugins/communication-resources/src/components/message/MessagesLoading.svelte
@@ -13,12 +13,13 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { Label } from '@hcengineering/ui'
+  import { Label, Loading } from '@hcengineering/ui'
 
   import communication from '../../plugin'
 </script>
 
-<div class="loader">
+<div class="loader" role="status" aria-live="polite" aria-busy="true">
+  <Loading size="small" />
   <Label label={communication.string.Loading} />
 </div>
 
@@ -28,6 +29,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 0.5rem;
     color: var(--global-secondary-TextColor);
     font-weight: 500;
     height: 5rem;


### PR DESCRIPTION
## Summary

Improve the chat messages loading UI for both visual and screen-reader users.

## Changes

- Added spinner next to loading label.
- Added live-region semantics on the loading container:
  - `role="status"`
  - `aria-live="polite"`
  - `aria-busy="true"`
- Added small spacing between spinner and label.

## Files

- `plugins/communication-resources/src/components/message/MessagesLoading.svelte`

## Why

The loading state is now more visible and is announced properly by assistive technologies.

## Testing

- Open a chat/thread where messages are fetched.
- Verify loading UI shows spinner + text.
- Verify no layout regressions in message list container.
- (Optional) Screen reader check: loading state is announced as a status update.