### PR TITLE
feat(notification-resources): add keyboard shortcuts and a11y semantics to inbox settings popup

### DIFF
--- a/plugins/notification-resources/src/components/inbox/SettingsPopup.svelte
+++ b/plugins/notification-resources/src/components/inbox/SettingsPopup.svelte
@@ -36,26 +36,31 @@
     if (key.code === 'ArrowUp') {
       key.stopPropagation()
       key.preventDefault()
-      list.select(selection - 1)
+      selectIndex(selection - 1)
       return true
     }
     if (key.code === 'ArrowDown') {
       key.stopPropagation()
       key.preventDefault()
-      list.select(selection + 1)
+      selectIndex(selection + 1)
       return true
     }
-    if (key.code === 'Enter') {
+    if (key.code === 'Home') {
+      key.stopPropagation()
+      key.preventDefault()
+      selectIndex(0)
+      return true
+    }
+    if (key.code === 'End') {
+      key.stopPropagation()
+      key.preventDefault()
+      selectIndex(items.length - 1)
+      return true
+    }
+    if (key.code === 'Enter' || key.code === 'Space') {
       key.preventDefault()
       key.stopPropagation()
-      items[selection]?.onToggle()
-      items = items.map((item, index) => {
-        if (index === selection) {
-          return { ...item, on: !item.on }
-        }
-
-        return item
-      })
+      toggleSelectedItem()
       return true
     }
     return false
@@ -66,16 +71,36 @@
   $: if (popupElement) {
     popupElement.focus()
   }
+
+  function selectIndex (index: number): void {
+    if (items.length === 0) return
+
+    list.select(Math.max(0, Math.min(index, items.length - 1)))
+  }
+
+  function toggleSelectedItem (): void {
+    const item = items[selection]
+    if (item === undefined) return
+
+    item.onToggle()
+    items = items.map((settingItem, index) => {
+      if (index === selection) {
+        return { ...settingItem, on: !settingItem.on }
+      }
+
+      return settingItem
+    })
+  }
 </script>
 
 <FocusHandler {manager} />
 
-<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class="selectPopup"
   bind:this={popupElement}
   tabindex="0"
+  role="dialog"
+  aria-label="Inbox settings"
   use:resizeObserver={() => {
     dispatch('changeContent')
   }}


### PR DESCRIPTION
## Summary

Enhance keyboard interaction and accessibility semantics in the inbox settings popup.

## Changes

- Added keyboard support:
  - `Home` -> first setting
  - `End` -> last setting
  - `Space` -> toggle selected setting (same as `Enter`)
- Refactored selection/toggle logic into:
  - `selectIndex` (bounded selection)
  - `toggleSelectedItem` (single-path toggle behavior)
- Added popup semantics:
  - `role="dialog"`
  - `aria-label="Inbox settings"`
- Removed previous a11y ignore comments for non-interactive tabindex/static interactions.

## Files

- `plugins/notification-resources/src/components/inbox/SettingsPopup.svelte`

## Why

This aligns popup behavior with common keyboard expectations and improves assistive-technology support.

## Testing

- Open Inbox settings popup.
- Verify:
  - `ArrowUp/ArrowDown` moves selection
  - `Home/End` jumps to first/last setting
  - `Enter/Space` toggles selected setting
  - `Tab` closes popup (existing behavior)
- Confirm toggles still work with mouse.