### PR TITLE
fix(tracker): parentIssue prop overrides draft when reopening create issue modal

### DIFF
--- a/plugins/tracker-resources/src/components/CreateIssue.svelte
+++ b/plugins/tracker-resources/src/components/CreateIssue.svelte
@@ -165,13 +165,15 @@
       return
     }
 
+    const _parentIssue = parentIssue
     return {
       ...draft,
       ...(status != null ? { status } : {}),
       ...(priority != null ? { priority } : {}),
       ...(assignee != null ? { assignee } : {}),
       ...(component != null ? { component } : {}),
-      ...(milestone != null ? { milestone } : {})
+      ...(milestone != null ? { milestone } : {}),
+      ...(_parentIssue !== undefined ? { parentIssue: _parentIssue._id } : {})
     }
   }
 

--- a/plugins/tracker-resources/src/components/SubIssues.svelte
+++ b/plugins/tracker-resources/src/components/SubIssues.svelte
@@ -18,7 +18,7 @@
   import { DraftController, draftsStore, getClient, deleteFile, createMarkup } from '@hcengineering/presentation'
   import tags from '@hcengineering/tags'
   import { isEmptyMarkup } from '@hcengineering/text'
-  import { Component, Issue, IssueDraft, IssueParentInfo, IssueStatus, Milestone, Project } from '@hcengineering/tracker'
+  import { Component, Issue, IssueDraft, IssueParentInfo, Milestone, Project } from '@hcengineering/tracker'
   import { Button, ExpandCollapse, Scroller } from '@hcengineering/ui'
   import { onDestroy } from 'svelte'
   import tracker from '../plugin'

--- a/plugins/tracker-resources/src/components/SubIssues.svelte
+++ b/plugins/tracker-resources/src/components/SubIssues.svelte
@@ -18,7 +18,7 @@
   import { DraftController, draftsStore, getClient, deleteFile, createMarkup } from '@hcengineering/presentation'
   import tags from '@hcengineering/tags'
   import { isEmptyMarkup } from '@hcengineering/text'
-  import { Component, Issue, IssueDraft, IssueParentInfo, Milestone, Project } from '@hcengineering/tracker'
+  import { Component, Issue, IssueDraft, IssueParentInfo, IssueStatus, Milestone, Project } from '@hcengineering/tracker'
   import { Button, ExpandCollapse, Scroller } from '@hcengineering/ui'
   import { onDestroy } from 'svelte'
   import tracker from '../plugin'


### PR DESCRIPTION
## Summary

Fixes two related issues in `tracker-resources`:

1. **Wrong parentIssue when reopening CreateIssue modal** (#10348): When a draft sub-issue exists and the modal is reopened, the draft's stale `parentIssue` overrides the `parentIssue` prop passed from `EditIssue`. Fixed by including `parentIssue` in the `getDefaultObjectFromDraft()` override map.
2. **Type error in `SubIssues.svelte` after #10598**: `Project.defaultIssueStatus` was made optional in #10598 but `SubIssues.svelte` assigned it directly to `AttachedData<Issue>.status` (required). Added explicit cast and removed leftover unused imports (`SortingOrder`, `makeRank`) from commit 58295e416.

## Changes

**`CreateIssue.svelte`**

- Add `parentIssue` to `getDefaultObjectFromDraft()` override list so the explicit prop wins over the saved draft
- Use local const `_parentIssue` to satisfy TypeScript narrowing for the mutable `export let` prop

**`SubIssues.svelte`**

- Cast `(subIssue.status ?? project.defaultIssueStatus)` to `Ref<IssueStatus>` to handle the now-optional `defaultIssueStatus`
- Remove unused imports `SortingOrder` and `makeRank` (left over from #10577)
- Add missing `IssueStatus` to tracker import

## Test plan

- Open an issue that has existing sub-issues
- Add a new sub-issue (CreateIssue modal opens)
- Dismiss the modal without saving (draft is persisted)
- Add another new sub-issue — verify the modal opens with the correct parent (the current issue, not whatever was in the draft)