### PR TITLE
fix(tracker): truncate long milestone titles on issue cards

### DIFF
--- a/plugins/tracker-resources/src/components/milestones/MilestoneEditor.svelte
+++ b/plugins/tracker-resources/src/components/milestones/MilestoneEditor.svelte
@@ -124,7 +124,12 @@
     style:flex-direction={twoRows ? 'column' : 'row'}
   >
     {#if (!Array.isArray(value) && value.milestone && value.milestone !== $activeMilestone && groupBy !== 'milestone') || shouldShowPlaceholder}
-      <div class="flex-row-center clear-mins" class:minus-margin-vSpace={kind === 'list-header'} class:compression style:width>
+      <div
+        class="flex-row-center clear-mins"
+        class:minus-margin-vSpace={kind === 'list-header'}
+        class:compression
+        style:width
+      >
         <MilestoneSelector
           {kind}
           {size}

--- a/plugins/tracker-resources/src/components/milestones/MilestoneEditor.svelte
+++ b/plugins/tracker-resources/src/components/milestones/MilestoneEditor.svelte
@@ -117,14 +117,14 @@
 {:else}
   <div
     bind:this={element}
-    class="flex flex-wrap clear-mins"
+    class="flex flex-wrap clear-mins overflow-hidden"
     style:max-width={maxWidth}
     class:minus-margin={kind === 'list-header'}
     class:label-wrapper={compression}
     style:flex-direction={twoRows ? 'column' : 'row'}
   >
     {#if (!Array.isArray(value) && value.milestone && value.milestone !== $activeMilestone && groupBy !== 'milestone') || shouldShowPlaceholder}
-      <div class="flex-row-center" class:minus-margin-vSpace={kind === 'list-header'} class:compression style:width>
+      <div class="flex-row-center clear-mins" class:minus-margin-vSpace={kind === 'list-header'} class:compression style:width>
         <MilestoneSelector
           {kind}
           {size}


### PR DESCRIPTION
## Summary

- Add `overflow-hidden` to the MilestoneEditor wrapper to prevent long milestone titles from overflowing the issue card
- Add `clear-mins` (`min-width: 0`) to the inner flex container so the child Button and its `overflow-label` span can properly truncate with ellipsis

## Issue

Fixes #9655

## Changes

- `MilestoneEditor.svelte`: Added `overflow-hidden` class to the outer wrapper div and `clear-mins` class to the inner flex-row-center div in the non-list rendering branch

## Testing

- Create or edit a milestone with a very long title
- View the issue card in the tracker kanban board
- Verify the milestone title is truncated with ellipsis instead of overflowing the card