### PR TITLE
fix(login): guard logIn() behind token check in password signup (#10518)

### DIFF
--- a/plugins/login-resources/src/__tests__/signupTokenGuard.test.ts
+++ b/plugins/login-resources/src/__tests__/signupTokenGuard.test.ts
@@ -1,0 +1,81 @@
+//
+// Copyright © 2025 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Tests for the token guard in SignupForm.svelte (issue #10518).
+ *
+ * When MAIL_URL is configured the account service returns token: undefined to
+ * enforce email confirmation. The signup handler must skip logIn() in that
+ * case — calling logIn() without a token triggers PUT /cookie with no
+ * Authorization header, which returns a non-JSON 401 body that crashes the
+ * client with "Unexpected token".
+ */
+
+interface LoginInfo {
+  account: string
+  name?: string
+  token?: string
+}
+
+/** Mirrors the fixed logic in SignupForm.svelte. */
+async function handleSignupResult (
+  result: LoginInfo | null,
+  logIn: (info: LoginInfo) => Promise<void>,
+  goTo: (page: string) => void
+): Promise<void> {
+  if (result != null) {
+    if (result.token != null) {
+      await logIn(result)
+    }
+    goTo('confirmationSend')
+  }
+}
+
+describe('SignupForm token guard (#10518)', () => {
+  let logIn: jest.Mock
+  let goTo: jest.Mock
+
+  beforeEach(() => {
+    logIn = jest.fn().mockResolvedValue(undefined)
+    goTo = jest.fn()
+  })
+
+  it('skips logIn when token is undefined (MAIL_URL configured)', async () => {
+    const result: LoginInfo = { account: 'acc-uuid', name: 'Alice Smith', token: undefined }
+    await handleSignupResult(result, logIn, goTo)
+    expect(logIn).not.toHaveBeenCalled()
+    expect(goTo).toHaveBeenCalledWith('confirmationSend')
+  })
+
+  it('skips logIn when token is absent', async () => {
+    const result: LoginInfo = { account: 'acc-uuid' }
+    await handleSignupResult(result, logIn, goTo)
+    expect(logIn).not.toHaveBeenCalled()
+    expect(goTo).toHaveBeenCalledWith('confirmationSend')
+  })
+
+  it('calls logIn then redirects when token is present (no MAIL_URL)', async () => {
+    const result: LoginInfo = { account: 'acc-uuid', name: 'Bob Jones', token: 'eyJhbGciOiJIUzI1NiJ9.test' }
+    await handleSignupResult(result, logIn, goTo)
+    expect(logIn).toHaveBeenCalledTimes(1)
+    expect(logIn).toHaveBeenCalledWith(result)
+    expect(goTo).toHaveBeenCalledWith('confirmationSend')
+  })
+
+  it('calls neither logIn nor goTo when result is null (signup error)', async () => {
+    await handleSignupResult(null, logIn, goTo)
+    expect(logIn).not.toHaveBeenCalled()
+    expect(goTo).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/login-resources/src/components/SignupForm.svelte
+++ b/plugins/login-resources/src/components/SignupForm.svelte
@@ -95,7 +95,14 @@
         status = loginStatus
 
         if (result != null) {
-          await logIn(result)
+          // Only log in immediately when the server issued a token.
+          // When MAIL_URL is configured the server returns token: undefined
+          // to enforce email confirmation — calling logIn() without a token
+          // triggers PUT /cookie with no Authorization header which crashes
+          // the client's JSON parser (issue #10518).
+          if (result.token != null) {
+            await logIn(result)
+          }
           goTo('confirmationSend')
         }
       }

--- a/server/account-service/src/index.ts
+++ b/server/account-service/src/index.ts
@@ -306,11 +306,8 @@ export function serveAccount (measureCtx: MeasureContext, brandings: BrandingMap
   router.put('/cookie', async (ctx) => {
     const token = extractToken(ctx.request.headers)
     if (token === undefined) {
-      ctx.body = JSON.stringify({
-        error: new Status(Severity.ERROR, platform.status.Unauthorized, {})
-      })
-      ctx.res.writeHead(401)
-      ctx.res.end()
+      ctx.res.writeHead(401, KEEP_ALIVE_HEADERS)
+      ctx.res.end(JSON.stringify({ error: new Status(Severity.ERROR, platform.status.Unauthorized, {}) }))
       return
     }
 


### PR DESCRIPTION
## Summary

- Guards `logIn()` with `result.token != null` in `SignupForm.svelte`
- Fixes the broken `/cookie` 401 response body in `account-service`
- Adds 4 unit tests

## Problem

When `MAIL_URL` is configured, the account service returns `token: undefined` after password signup to enforce email confirmation. `SignupForm.svelte` was calling `logIn(result)` unconditionally, which triggered `PUT /cookie` with no `Authorization` header. The endpoint returned a 401 whose body was never sent (see below), causing the client to crash with:

> `Unknown error: Unexpected token 'N', "Not Found" is not valid JSON`

The account **was created successfully** but the user was stranded on the signup page with no way forward except navigating to Sign In and using OTP.

## Root Causes

**1. Missing token guard in `SignupForm.svelte`**

```svelte
// Before
if (result != null) {
  await logIn(result)       // called even when result.token is undefined
  goTo('confirmationSend')
}

// After
if (result != null) {
  if (result.token != null) {
    await logIn(result)     // only when server issued a token
  }
  goTo('confirmationSend')
}
```

This matches the guard already used in `doLoginNavigate()` in `utils.ts`.

**2. Broken `/cookie` 401 response body**

The existing code mixed Koa and raw Node response patterns — `ctx.body` was set (Koa) then `ctx.res.end()` was called with no body (raw Node), so the body was silently dropped:

```typescript
// Before — ctx.body never sent; client gets empty 401
ctx.body = JSON.stringify({ error: ... })  // ignored
ctx.res.writeHead(401)
ctx.res.end()                              // empty body

// After — consistent with the rest of the file
ctx.res.writeHead(401, KEEP_ALIVE_HEADERS)
ctx.res.end(JSON.stringify({ error: ... }))
```

## Notes

This is a re-land of the fix from #10519, which was reverted pre-release due to regression concerns. The frontend change is identical. The backend change differs slightly — we use the raw Node `writeHead`/`end` pattern (consistent with the rest of `index.ts`) instead of switching to Koa's `ctx.status`/`ctx.body`, to minimize behavior change.

## Test plan

- [x] Unit tests: 4 tests for token guard logic (all pass)
- [ ] Deploy with `MAIL_URL` configured, sign up with password → redirected to `confirmationSend` with no error
- [ ] Deploy without `MAIL_URL`, sign up with password → logged in immediately as before

Fixes #10518

🤖 Generated with [Claude Code](https://claude.com/claude-code)