### PR TITLE
Fix social link save

### DIFF
--- a/plugins/contact-resources/src/components/ChannelsDropdown.svelte
+++ b/plugins/contact-resources/src/components/ChannelsDropdown.svelte
@@ -259,7 +259,8 @@
             if (result.trim() === '') {
               remove(n)
             } else if (item.value.trim() !== result.trim()) {
-              item.value = result
+              item.value = result.trim()
+              item.channel.value = item.value
               saveItems()
               dispatch('save', item.channel)
             }


### PR DESCRIPTION
Steps to reproduce:
1. Add new email social link
2. Click go to channel button without save button click
Observed behaviour:
Empty social link is created

<img width="394" height="131" alt="Screenshot 2026-03-19 at 15 59 00" src="https://github.com/user-attachments/assets/7b715743-f4a0-41eb-8333-729df3caf774" />
