### PR TITLE
fix(github): apply guest token to images in markdown sync

### DIFF
--- a/services/github/pod-github/src/sync/issues.ts
+++ b/services/github/pod-github/src/sync/issues.ts
@@ -523,9 +523,7 @@ export class IssueSyncManager extends IssueSyncManagerBase implements DocSyncMan
               info.repository as Ref<GithubIntegrationRepository>,
               container.project,
               taskTypes[0]._id,
-              repo as GithubIntegrationRepository & {
-                repository: IntegrationRepositoryData
-              },
+              repo,
               !markdownCompatible
             )
           },

--- a/services/github/pod-github/src/worker.ts
+++ b/services/github/pod-github/src/worker.ts
@@ -244,7 +244,10 @@ export class GithubWorker implements IntegrationManager {
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/browse/?workspace=${this.workspace.uuid}`),
       // TODO storage URL
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/files/${this.workspace.uuid}/`),
-      preprocessor ?? (async (nodes) => { appendGuestLinkToImage(nodes, this.workspace.uuid) })
+      preprocessor ??
+        (async (nodes) => {
+          appendGuestLinkToImage(nodes, this.workspace.uuid)
+        })
     )
   }
 

--- a/services/github/pod-github/src/worker.ts
+++ b/services/github/pod-github/src/worker.ts
@@ -86,6 +86,7 @@ import { ReviewCommentSyncManager } from './sync/reviewComments'
 import { ReviewThreadSyncManager } from './sync/reviewThreads'
 import { ReviewSyncManager } from './sync/reviews'
 import { UsersSyncManager, fetchViewerDetails } from './sync/users'
+import { appendGuestLinkToImage } from './sync/guest'
 import { errorToObj } from './sync/utils'
 import {
   ContainerFocus,
@@ -243,7 +244,7 @@ export class GithubWorker implements IntegrationManager {
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/browse/?workspace=${this.workspace.uuid}`),
       // TODO storage URL
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/files/${this.workspace.uuid}/`),
-      preprocessor
+      preprocessor ?? (async (nodes) => { appendGuestLinkToImage(nodes, this.workspace.uuid) })
     )
   }
 


### PR DESCRIPTION
## Summary

Fixes #10516

- `appendGuestLinkToImage()` in `services/github/pod-github/src/sync/guest.ts` stamps a guest JWT token onto image URLs before serialization to GitHub markdown
- The function existed but was dead code — never called from `getMarkdown()`
- This PR adds it as the default preprocessor via `preprocessor ?? (async (nodes) => { appendGuestLinkToImage(nodes, this.workspace.uuid) })`, so all 10+ call sites automatically get image token injection when no custom preprocessor is provided
- The serializer at `foundations/core/packages/text-markdown/src/serializer.ts:175-191` already handles `attrs.token` → `&token=` in URLs

## Test plan

- [ ] Create a Huly issue with an inline image in a GitHub-connected project
- [ ] Verify the synced GitHub issue shows the image (URL contains `&token=<guest-jwt>`)
- [ ] Verify that call sites passing an explicit preprocessor still work as before (nullish coalescing preserves existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)