### PR TITLE
Try to fix unstable 'find avg' tests

### DIFF
--- a/ws-tests/api-tests/src/__tests__/rest.test.ts
+++ b/ws-tests/api-tests/src/__tests__/rest.test.ts
@@ -42,6 +42,7 @@ import contact, { ensureEmployee, type SocialIdentityRef, type Person } from '@h
 import { generateToken } from '@hcengineering/server-token'
 
 describe('rest-api-server', () => {
+  const FIND_PERFORMANCE_TEST_TIMEOUT_MS = 20000
   const testCtx = new MeasureMetricsContext('test', {})
   const wsName = 'api-tests'
   let apiWorkspace1: WorkspaceToken
@@ -174,13 +175,13 @@ describe('rest-api-server', () => {
 
   it('find avg', async () => {
     const conn = connect()
-    await checkFindPerformance(conn) // 5ms max per operation
-  })
+    await checkFindPerformance(conn) // 15ms max per operation
+  }, FIND_PERFORMANCE_TEST_TIMEOUT_MS)
 
   it('find avg-europe', async () => {
     const conn = connect(apiWorkspace2)
-    await checkFindPerformance(conn) // 5ms max per operation
-  })
+    await checkFindPerformance(conn) // 15ms max per operation
+  }, FIND_PERFORMANCE_TEST_TIMEOUT_MS)
 
   it('add space', async () => {
     const conn = connect()
@@ -296,5 +297,5 @@ async function checkFindPerformance (conn: RestClient): Promise<void> {
   const avg = total / ops
   // console.log('ops:', ops, 'total:', total, 'avg:', )
   expect(ops).toEqual(attempts)
-  expect(avg).toBeLessThan(10)
+  expect(avg).toBeLessThan(15)
 }

--- a/ws-tests/api-tests/src/__tests__/rest.test.ts
+++ b/ws-tests/api-tests/src/__tests__/rest.test.ts
@@ -42,7 +42,6 @@ import contact, { ensureEmployee, type SocialIdentityRef, type Person } from '@h
 import { generateToken } from '@hcengineering/server-token'
 
 describe('rest-api-server', () => {
-  const FIND_PERFORMANCE_TEST_TIMEOUT_MS = 20000
   const testCtx = new MeasureMetricsContext('test', {})
   const wsName = 'api-tests'
   let apiWorkspace1: WorkspaceToken
@@ -175,13 +174,13 @@ describe('rest-api-server', () => {
 
   it('find avg', async () => {
     const conn = connect()
-    await checkFindPerformance(conn) // 15ms max per operation
-  }, FIND_PERFORMANCE_TEST_TIMEOUT_MS)
+    await checkFindPerformance(conn) // 5ms max per operation
+  }, 10000)
 
   it('find avg-europe', async () => {
     const conn = connect(apiWorkspace2)
-    await checkFindPerformance(conn) // 15ms max per operation
-  }, FIND_PERFORMANCE_TEST_TIMEOUT_MS)
+    await checkFindPerformance(conn) // 5ms max per operation
+  }, 10000)
 
   it('add space', async () => {
     const conn = connect()
@@ -297,5 +296,5 @@ async function checkFindPerformance (conn: RestClient): Promise<void> {
   const avg = total / ops
   // console.log('ops:', ops, 'total:', total, 'avg:', )
   expect(ops).toEqual(attempts)
-  expect(avg).toBeLessThan(15)
+  expect(avg).toBeLessThan(10)
 }


### PR DESCRIPTION
Tests do not always complete within the default timeout:

```
    ✕ find avg (5002 ms)
    ✓ find avg-europe (4961 ms)
    ● rest-api-server › find avg

    thrown: "Exceeded timeout of 5000 ms for a test.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
```