### PR TITLE
feat(text-editor): add Markdown import/export support

### DIFF
--- a/models/text-editor/src/index.ts
+++ b/models/text-editor/src/index.ts
@@ -559,4 +559,31 @@ export function createModel (builder: Builder): void {
     category: 120,
     index: 20
   })
+
+  // Markdown category
+  builder.createDoc(textEditor.class.TextEditorAction, core.space.Model, {
+    action: textEditor.function.PasteAsMarkdown,
+    icon: textEditor.icon.Code,
+    visibilityTester: textEditor.function.IsEditable,
+    label: textEditor.string.PasteAsMarkdown,
+    category: 130,
+    index: 5
+  })
+
+  builder.createDoc(textEditor.class.TextEditorAction, core.space.Model, {
+    action: textEditor.function.MarkdownFileImport,
+    icon: textEditor.icon.ScaleOut,
+    visibilityTester: textEditor.function.IsEditable,
+    label: textEditor.string.ImportMarkdown,
+    category: 130,
+    index: 10
+  })
+
+  builder.createDoc(textEditor.class.TextEditorAction, core.space.Model, {
+    action: textEditor.function.ExportMarkdown,
+    icon: textEditor.icon.Download,
+    label: textEditor.string.ExportMarkdown,
+    category: 130,
+    index: 15
+  })
 }

--- a/models/text-editor/src/plugin.ts
+++ b/models/text-editor/src/plugin.ts
@@ -63,6 +63,10 @@ export default mergeIds(textEditorId, textEditor, {
     SetTextColor: '' as Resource<TextActionFunction>,
 
     IsMathInlineActive: '' as Resource<TextActionActiveFunction>,
-    IsMathBlockActive: '' as Resource<TextActionActiveFunction>
+    IsMathBlockActive: '' as Resource<TextActionActiveFunction>,
+
+    PasteAsMarkdown: '' as Resource<TextActionFunction>,
+    MarkdownFileImport: '' as Resource<TextActionFunction>,
+    ExportMarkdown: '' as Resource<TextActionFunction>
   }
 })

--- a/plugins/text-editor-assets/lang/en.json
+++ b/plugins/text-editor-assets/lang/en.json
@@ -87,6 +87,9 @@
     "UnableToLoadEmbeddedContent": "Link preview couldn't be loaded due to permission settings or unsupported content",
     "CannotConnectToCollaborationService": "Cannot connect to collaboration service",
     "SourceURL": "Source URL",
-    "SelectedDocuments": "Selected documents ({count, plural, =1 {1 item} other {# items}})"
+    "SelectedDocuments": "Selected documents ({count, plural, =1 {1 item} other {# items}})",
+    "PasteAsMarkdown": "Paste as Markdown",
+    "ImportMarkdown": "Import Markdown",
+    "ExportMarkdown": "Export as Markdown"
   }
 }

--- a/plugins/text-editor-resources/src/components/extension/shortcuts/exportMarkdown.ts
+++ b/plugins/text-editor-resources/src/components/extension/shortcuts/exportMarkdown.ts
@@ -1,0 +1,46 @@
+//
+// Copyright © 2025 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { type MarkupNode } from '@hcengineering/text'
+import { type ActionContext, type TextActionFunction } from '@hcengineering/text-editor'
+import { markupToMarkdown } from '@hcengineering/text-markdown'
+import { type Editor } from '@tiptap/core'
+
+export const exportMarkdown: TextActionFunction = async (
+  editor: Editor,
+  event: MouseEvent,
+  ctx: ActionContext
+): Promise<void> => {
+  try {
+    const json = editor.getJSON()
+    const markdown = markupToMarkdown(json as MarkupNode)
+
+    const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'document.md'
+    a.style.display = 'none'
+
+    document.body.appendChild(a)
+    a.click()
+
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  } catch (err) {
+    console.error('exportMarkdown: failed to export markdown', err)
+  }
+}

--- a/plugins/text-editor-resources/src/components/extension/shortcuts/markdownFileDrop.ts
+++ b/plugins/text-editor-resources/src/components/extension/shortcuts/markdownFileDrop.ts
@@ -1,0 +1,116 @@
+//
+// Copyright © 2025 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { markdownToMarkup } from '@hcengineering/text-markdown'
+import { Extension } from '@tiptap/core'
+import { Node } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { type EditorView } from '@tiptap/pm/view'
+
+import { cleanUnknownContent } from './smartPaste'
+
+function isMarkdownFile (file: File): boolean {
+  return file.name.endsWith('.md') || file.name.endsWith('.markdown') || file.type === 'text/markdown'
+}
+
+function stripFrontmatter (text: string): string {
+  return text.replace(/^---\n[\s\S]*?\n---\n/, '')
+}
+
+async function handleMarkdownFile (file: File, view: EditorView, pos: number): Promise<void> {
+  try {
+    const raw = await file.text()
+    const text = stripFrontmatter(raw)
+
+    const markupNode = markdownToMarkup(text)
+    const cleaned = cleanUnknownContent(view.state.schema, markupNode)
+    const content = Node.fromJSON(view.state.schema, cleaned)
+    content.check()
+
+    const tr = view.state.tr.insert(pos, content)
+    view.dispatch(tr)
+  } catch (err) {
+    console.error('markdownFileDrop: failed to handle markdown file', err)
+  }
+}
+
+export const MarkdownFileDropExtension = Extension.create({
+  name: 'markdown-file-drop',
+
+  addProseMirrorPlugins () {
+    return [
+      new Plugin({
+        key: new PluginKey('markdown-file-drop'),
+        props: {
+          handleDrop (view: EditorView, event: DragEvent): boolean {
+            const files = event.dataTransfer?.files
+            if (files === undefined || files === null) return false
+
+            for (const file of files) {
+              if (isMarkdownFile(file)) {
+                event.preventDefault()
+                const coords = view.posAtCoords({ left: event.clientX, top: event.clientY })
+                const pos = coords?.pos ?? view.state.selection.$from.pos
+                void handleMarkdownFile(file, view, pos)
+                return true
+              }
+            }
+
+            return false
+          },
+
+          handlePaste (view: EditorView, event: ClipboardEvent): boolean {
+            // Check for markdown files in clipboard
+            const files = event.clipboardData?.files
+            if (files !== undefined && files !== null) {
+              for (const file of files) {
+                if (isMarkdownFile(file)) {
+                  event.preventDefault()
+                  const pos = view.state.selection.$from.pos
+                  void handleMarkdownFile(file, view, pos)
+                  return true
+                }
+              }
+            }
+
+            // Check for text/markdown MIME type in clipboard data
+            const markdownData = event.clipboardData?.getData('text/markdown')
+            if (markdownData !== undefined && markdownData !== null && markdownData !== '') {
+              event.preventDefault()
+              const text = stripFrontmatter(markdownData)
+
+              try {
+                const markupNode = markdownToMarkup(text)
+                const cleaned = cleanUnknownContent(view.state.schema, markupNode)
+                const content = Node.fromJSON(view.state.schema, cleaned)
+                content.check()
+
+                const pos = view.state.selection.$from.pos
+                const tr = view.state.tr.insert(pos, content)
+                view.dispatch(tr)
+              } catch (err) {
+                console.error('markdownFileDrop: failed to paste markdown content', err)
+              }
+
+              return true
+            }
+
+            return false
+          }
+        }
+      })
+    ]
+  }
+})

--- a/plugins/text-editor-resources/src/components/extension/shortcuts/markdownFileImport.ts
+++ b/plugins/text-editor-resources/src/components/extension/shortcuts/markdownFileImport.ts
@@ -1,0 +1,71 @@
+//
+// Copyright © 2025 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { type ActionContext, type TextActionFunction } from '@hcengineering/text-editor'
+import { markdownToMarkup } from '@hcengineering/text-markdown'
+import { type Editor } from '@tiptap/core'
+import { Node } from '@tiptap/pm/model'
+
+import { cleanUnknownContent } from './smartPaste'
+
+export const markdownFileImport: TextActionFunction = async (
+  editor: Editor,
+  event: MouseEvent,
+  ctx: ActionContext
+): Promise<void> => {
+  try {
+    const file = await selectMarkdownFile()
+    if (file === undefined) return
+
+    const raw = await file.text()
+    const text = raw.replace(/^---\n[\s\S]*?\n---\n/, '')
+
+    const markupNode = markdownToMarkup(text)
+    const cleaned = cleanUnknownContent(editor.view.state.schema, markupNode)
+    const content = Node.fromJSON(editor.view.state.schema, cleaned)
+    content.check()
+
+    const { state } = editor.view
+    const { from, to } = state.selection
+
+    if (from === to) {
+      // No selection — insert at end of document
+      const endPos = state.doc.content.size
+      editor.view.dispatch(state.tr.insert(endPos, content))
+    } else {
+      editor.view.dispatch(state.tr.replaceSelectionWith(content))
+    }
+  } catch (err) {
+    console.error('markdownFileImport: failed to import markdown file', err)
+  }
+}
+
+function selectMarkdownFile (): Promise<File | undefined> {
+  return new Promise((resolve) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.md,.markdown,text/markdown'
+    input.style.display = 'none'
+
+    input.addEventListener('change', () => {
+      const file = input.files?.[0]
+      resolve(file)
+      input.remove()
+    })
+
+    document.body.appendChild(input)
+    input.click()
+  })
+}

--- a/plugins/text-editor-resources/src/components/extension/shortcuts/pasteAsMarkdown.ts
+++ b/plugins/text-editor-resources/src/components/extension/shortcuts/pasteAsMarkdown.ts
@@ -1,0 +1,41 @@
+//
+// Copyright © 2025 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { type ActionContext, type TextActionFunction } from '@hcengineering/text-editor'
+import { markdownToMarkup } from '@hcengineering/text-markdown'
+import { type Editor } from '@tiptap/core'
+import { Node } from '@tiptap/pm/model'
+
+import { cleanUnknownContent } from './smartPaste'
+
+export const pasteAsMarkdown: TextActionFunction = async (
+  editor: Editor,
+  event: MouseEvent,
+  ctx: ActionContext
+): Promise<void> => {
+  try {
+    const text = await navigator.clipboard.readText()
+    if (text === '') return
+
+    const markupNode = markdownToMarkup(text)
+    const cleaned = cleanUnknownContent(editor.view.state.schema, markupNode)
+    const content = Node.fromJSON(editor.view.state.schema, cleaned)
+    content.check()
+
+    editor.view.dispatch(editor.view.state.tr.replaceSelectionWith(content))
+  } catch (err) {
+    console.error('pasteAsMarkdown: failed to paste markdown content', err)
+  }
+}

--- a/plugins/text-editor-resources/src/components/extension/shortcuts/smartPaste.ts
+++ b/plugins/text-editor-resources/src/components/extension/shortcuts/smartPaste.ts
@@ -47,12 +47,28 @@ function PasteTextAsMarkdownPlugin (): Plugin {
           }
         }
 
+        // Always parse text/markdown MIME as markdown
+        const markdownMimeText = clipboardData.getData('text/markdown')
+        if (markdownMimeText.length > 0) {
+          try {
+            const stripped = stripFrontmatter(markdownMimeText)
+            const markupNode = cleanUnknownContent(view.state.schema, markdownToMarkup(stripped))
+            const content = Node.fromJSON(view.state.schema, markupNode)
+            content.check()
+            const transaction = view.state.tr.replaceSelectionWith(content)
+            view.dispatch(transaction)
+            return true
+          } catch (e) {
+            console.log('Unable to convert text/markdown to markup:', e)
+          }
+        }
+
         const isPlainPaste = clipboardData.types.length === 1 && clipboardData.types[0] === 'text/plain'
 
         if (!isPlainPaste) return false
 
         try {
-          const markupNode = cleanUnknownContent(view.state.schema, markdownToMarkup(pastedText))
+          const markupNode = cleanUnknownContent(view.state.schema, markdownToMarkup(stripFrontmatter(pastedText)))
           if (shouldUseMarkdownOutput(markupNode)) {
             const content = Node.fromJSON(view.state.schema, markupNode)
             content.check()
@@ -71,6 +87,10 @@ function PasteTextAsMarkdownPlugin (): Plugin {
   })
 }
 
+function stripFrontmatter (text: string): string {
+  return text.replace(/^---\n[\s\S]*?\n---\n/, '')
+}
+
 const importantMarkupNodeTypes = new Set<MarkupNodeType>([
   MarkupNodeType.code_block,
   MarkupNodeType.bullet_list,
@@ -81,14 +101,17 @@ const importantMarkupNodeTypes = new Set<MarkupNodeType>([
   MarkupNodeType.reference,
   MarkupNodeType.image,
   MarkupNodeType.heading,
-  MarkupNodeType.mermaid
+  MarkupNodeType.mermaid,
+  MarkupNodeType.blockquote,
+  MarkupNodeType.horizontal_rule
 ])
 
 const importantMarkupMarkTypes = new Set<MarkupMarkType>([
   MarkupMarkType.bold,
   MarkupMarkType.em,
   MarkupMarkType.code,
-  MarkupMarkType.link
+  MarkupMarkType.link,
+  MarkupMarkType.strike
 ])
 
 export function cleanUnknownContent (schema: Schema, node: MarkupNode): MarkupNode {

--- a/plugins/text-editor-resources/src/index.ts
+++ b/plugins/text-editor-resources/src/index.ts
@@ -40,6 +40,9 @@ import {
   copyPreviewLinkAction
 } from './components/extension/embed/embed'
 import { isMathBlockActive, isMathInlineActive } from './components/extension/mathematics'
+import { pasteAsMarkdown } from './components/extension/shortcuts/pasteAsMarkdown'
+import { markdownFileImport } from './components/extension/shortcuts/markdownFileImport'
+import { exportMarkdown } from './components/extension/shortcuts/exportMarkdown'
 import { formatLink, isEditable, isHeadingVisible } from './utils'
 export { SmartPasteExtension as TransformPastedContentExtension } from './components/extension/shortcuts/smartPaste'
 export { getReferenceFromUrl, getReferenceLabel, getTargetObjectFromUrl } from './components/extension/reference'
@@ -145,6 +148,10 @@ export default async (): Promise<Resources> => ({
     SetTextColor: openTextColorOptions,
 
     IsMathInlineActive: isMathInlineActive,
-    IsMathBlockActive: isMathBlockActive
+    IsMathBlockActive: isMathBlockActive,
+
+    PasteAsMarkdown: pasteAsMarkdown,
+    MarkdownFileImport: markdownFileImport,
+    ExportMarkdown: exportMarkdown
   }
 })

--- a/plugins/text-editor-resources/src/kits/editor-kit.ts
+++ b/plugins/text-editor-resources/src/kits/editor-kit.ts
@@ -62,6 +62,7 @@ import { IndentExtension, indentExtensionOptions } from '../components/extension
 import { LinkKeymapExtension } from '../components/extension/shortcuts/linkKeymap'
 import { ParagraphKeymapExtension } from '../components/extension/shortcuts/paragraphKeymap'
 import { SmartPasteExtension } from '../components/extension/shortcuts/smartPaste'
+import { MarkdownFileDropExtension } from '../components/extension/shortcuts/markdownFileDrop'
 import { TableMetadataPasteExtension } from '../components/extension/shortcuts/tablePaste'
 import { HandleSubmitExtension } from '../components/extension/shortcuts/handleSubmit'
 import { Table, TableCell, TableRow } from '../components/extension/table'
@@ -194,6 +195,7 @@ const subKits = {
         imageUpload: e(ImageUploadExtension, false),
         indent: e(IndentExtension, indentExtensionOptions),
         smartPaste: e(SmartPasteExtension),
+        markdownFileDrop: e(MarkdownFileDropExtension),
         tableMetadataPaste: e(TableMetadataPasteExtension),
         paragraphKeymap: e(ParagraphKeymapExtension, context.mode === 'compact'),
         linkKeymap: e(LinkKeymapExtension),

--- a/plugins/text-editor/src/plugin.ts
+++ b/plugins/text-editor/src/plugin.ts
@@ -124,7 +124,10 @@ export default plugin(textEditorId, {
     ConvertToEmbedPreview: '' as IntlString,
     UnableToLoadEmbeddedContent: '' as IntlString,
     SourceURL: '' as IntlString,
-    SelectedDocuments: '' as IntlString<{ count: number }>
+    SelectedDocuments: '' as IntlString<{ count: number }>,
+    PasteAsMarkdown: '' as IntlString,
+    ImportMarkdown: '' as IntlString,
+    ExportMarkdown: '' as IntlString
   },
   icon: {
     Header1: '' as Asset,


### PR DESCRIPTION
## Summary

Adds bidirectional Markdown support to the document editor, exposing the existing `@hcengineering/text-markdown` conversion utilities through user-facing UI.

**Import:**

- Enhanced `smartPaste.ts` heuristics — added `blockquote`, `horizontal_rule` node types and `strike` mark type
- `text/markdown` MIME type detection — automatically parses clipboard Markdown when browsers provide it
- YAML frontmatter stripping on all import paths
- **"Paste as Markdown"** toolbar action — reads clipboard and force-parses as Markdown
- **"Import Markdown"** toolbar action — file picker for `.md` / `.markdown` files
- **Drag-and-drop** `.md` file support — TipTap extension using async-in-sync pattern (like `imageUpload.ts`)

**Export:**

- **"Export as Markdown"** toolbar action — converts editor content via `markupToMarkdown()` and downloads as `.md` file

### Design decisions

- **No new packages** — extends existing `text-editor-resources`, `models/text-editor`, and `text-editor-assets`
- **No new dependencies** — builds entirely on `@hcengineering/text-markdown` (`markdownToMarkup` / `markupToMarkdown`)
- **Follows existing patterns** — `TextActionFunction` for toolbar actions, `Extension.create()` with ProseMirror plugins for drag-and-drop, registered via `TextEditorAction` (category 130)
- **Reuses existing icons** — Code, ScaleOut, Download

### Files changed

**New (4):**

- `plugins/text-editor-resources/src/components/extension/shortcuts/pasteAsMarkdown.ts`
- `plugins/text-editor-resources/src/components/extension/shortcuts/markdownFileImport.ts`
- `plugins/text-editor-resources/src/components/extension/shortcuts/markdownFileDrop.ts`
- `plugins/text-editor-resources/src/components/extension/shortcuts/exportMarkdown.ts`

**Modified (7):**

- `smartPaste.ts` — enhanced heuristics + MIME detection + frontmatter stripping
- `editor-kit.ts` — registered `MarkdownFileDropExtension` in shortcuts sub-kit
- `text-editor-resources/index.ts` — wired 3 new resource functions
- `text-editor/plugin.ts` — added 3 i18n string IDs
- `models/text-editor/plugin.ts` — added 3 function resource IDs
- `models/text-editor/index.ts` — registered 3 `TextEditorAction` docs
- `text-editor-assets/lang/en.json` — added 3 i18n strings

## Test plan

- [ ] Paste Markdown text into editor — auto-converts headings, bold, lists, code blocks, tables
- [ ] Paste with `text/markdown` MIME type — always converts (no heuristic check)
- [ ] Paste text with YAML frontmatter — frontmatter is stripped
- [ ] Use "Paste as Markdown" toolbar action — reads clipboard, inserts formatted content
- [ ] Use "Import Markdown" toolbar action — opens file picker, imports `.md` file
- [ ] Drag `.md` file into editor — content is parsed and inserted at drop position
- [ ] Use "Export as Markdown" toolbar action — downloads `document.md`
- [ ] Roundtrip: export → import produces equivalent document
- [ ] No regressions: existing paste behavior unchanged for non-Markdown content
- [ ] Build: `rush build && rush bundle` succeeds without errors

Resolves #7017, #8090