### PR TITLE
fix(github): guard REST octokit in comment sync

### DIFF
--- a/services/github/pod-github/src/sync/comments.ts
+++ b/services/github/pod-github/src/sync/comments.ts
@@ -24,7 +24,7 @@ import {
   githubExternalSyncVersion,
   githubSyncVersion
 } from '../types'
-import { collectUpdate, deleteObjects, ensureGraphQLOctokit, errorToObj, getSince, isGHWriteAllowed } from './utils'
+import { collectUpdate, deleteObjects, ensureGraphQLOctokit, ensureRESTOctokit, errorToObj, getSince, isGHWriteAllowed } from './utils'
 
 import { Analytics } from '@hcengineering/analytics'
 import { IssueComment, IssueCommentCreatedEvent, IssueCommentEvent } from '@octokit/webhooks-types'
@@ -353,7 +353,10 @@ export class CommentSyncManager implements DocSyncManager {
 
     if (Object.keys(platformUpdate).length > 0) {
       // Check and update body with external
-      const okit = (await this.provider.getOctokit(ctx, existing.modifiedBy)) ?? container.container.octokit
+      const okit = ensureRESTOctokit(
+        (await this.provider.getOctokit(ctx, existing.modifiedBy)) ?? container.container.octokit,
+        container
+      )
       const mdown = await this.provider.getMarkdown(existingComment.message)
       if (mdown.trim().length > 0) {
         await okit.rest.issues.updateComment({
@@ -426,7 +429,10 @@ export class CommentSyncManager implements DocSyncManager {
       return {}
     }
     const chatMessage = existing as ChatMessage
-    const okit = (await this.provider.getOctokit(ctx, chatMessage.modifiedBy)) ?? container.container.octokit
+    const okit = ensureRESTOctokit(
+      (await this.provider.getOctokit(ctx, chatMessage.modifiedBy)) ?? container.container.octokit,
+      container
+    )
 
     // No external version yet, create it.
     try {

--- a/services/github/pod-github/src/sync/utils.ts
+++ b/services/github/pod-github/src/sync/utils.ts
@@ -51,6 +51,17 @@ export function ensureGraphQLOctokit (okit: Octokit | undefined, container: Cont
 }
 
 /**
+ * Ensures an Octokit instance has the REST API available.
+ * If the provided okit doesn't have rest.issues, falls back to container.octokit which is guaranteed to have it.
+ */
+export function ensureRESTOctokit (okit: Octokit | undefined, container: ContainerFocus): Octokit {
+  if (okit !== undefined && typeof (okit as any).rest?.issues?.createComment === 'function') {
+    return okit
+  }
+  return container.container.octokit
+}
+
+/**
  * @public
  */
 export function collectUpdate<T extends Doc> (


### PR DESCRIPTION
## Summary

- Adds `ensureRESTOctokit()` guard (mirrors the existing `ensureGraphQLOctokit()` from #10442) to validate the `.rest` plugin is available on user-scoped Octokit instances
- Applies the guard to both `createGithubComment` and `updateComment` paths in `CommentSyncManager`

This fixes `TypeError: okit.rest.issues.createComment is not a function` when syncing comments from Huly → GitHub. Same root cause as #10442 (`okit.graphql is not a function`), which only covered GraphQL calls but missed the two REST calls in `comments.ts`.

Fixes #10691

## Test plan

- [ ] Create a comment in Huly on a GitHub-synced issue → verify it appears on GitHub
- [ ] Edit a comment in Huly on a GitHub-synced issue → verify the update reflects on GitHub
- [ ] Verify GitHub → Huly comment sync still works