### PR TITLE
feat: add spellcheck prop to text editor components

### DIFF
--- a/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
@@ -95,6 +95,7 @@
   export let refActions: RefAction[] = []
 
   export let editorAttributes: Record<string, string> = {}
+  export let spellcheck: boolean = true
   export let overflow: 'auto' | 'none' = 'none'
   export let boundary: HTMLElement | undefined = undefined
 
@@ -427,7 +428,8 @@
       editorProps: {
         attributes: mergeAttributes(defaultEditorAttributes, editorAttributes, {
           class: 'flex-grow',
-          translate: readonly ? 'yes' : 'no'
+          translate: readonly ? 'yes' : 'no',
+          spellcheck: spellcheck ? 'true' : 'false'
         })
       },
       enableContentCheck: true,

--- a/plugins/text-editor-resources/src/components/CollaboratorEditor.svelte
+++ b/plugins/text-editor-resources/src/components/CollaboratorEditor.svelte
@@ -39,6 +39,7 @@
 
   export let overflow: 'auto' | 'none' = 'auto'
   export let editorAttributes: Record<string, string> = {}
+  export let spellcheck: boolean = true
   export let boundary: HTMLElement | undefined = undefined
 
   export let attachFile: FileAttachFunction | undefined = undefined
@@ -93,6 +94,7 @@
     {boundary}
     {attachFile}
     {editorAttributes}
+    {spellcheck}
     {kitOptions}
     {requestSideSpace}
     on:editor

--- a/plugins/text-editor-resources/src/components/StyledTextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/StyledTextEditor.svelte
@@ -37,6 +37,7 @@
   export let autofocus = false
   export let full = false
   export let editorAttributes: Record<string, string> = {}
+  export let spellcheck: boolean = true
   export let extraActions: RefAction[] = []
   export let boundary: HTMLElement | undefined = undefined
   export let kitOptions: Partial<EditorKitOptions> = {}
@@ -168,6 +169,7 @@
             editorAttributes={mergedEditorAttributes}
             bind:content
             {placeholder}
+            {spellcheck}
             bind:this={editor}
             on:value
             on:content={(ev) => {

--- a/plugins/text-editor-resources/src/components/TextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/TextEditor.svelte
@@ -34,6 +34,7 @@
   export let placeholderParams: Record<string, any> = {}
   export let supportSubmit = true
   export let editorAttributes: Record<string, string> = {}
+  export let spellcheck: boolean = true
   export let boundary: HTMLElement | undefined = undefined
   export let autofocus: FocusPosition = false
   export let onPaste: ((view: EditorView, event: ClipboardEvent) => boolean) | undefined = undefined
@@ -159,7 +160,7 @@
       enableContentCheck: true,
       element,
       editorProps: {
-        attributes: mergeAttributes(defaultEditorAttributes, editorAttributes),
+        attributes: mergeAttributes(defaultEditorAttributes, editorAttributes, { spellcheck: spellcheck ? 'true' : 'false' }),
         handlePaste: onPaste,
         handleKeyDown: (view, event) => {
           if (onKeyDown !== undefined) {

--- a/plugins/text-editor-resources/src/components/TextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/TextEditor.svelte
@@ -160,7 +160,9 @@
       enableContentCheck: true,
       element,
       editorProps: {
-        attributes: mergeAttributes(defaultEditorAttributes, editorAttributes, { spellcheck: spellcheck ? 'true' : 'false' }),
+        attributes: mergeAttributes(defaultEditorAttributes, editorAttributes, {
+          spellcheck: spellcheck ? 'true' : 'false'
+        }),
         handlePaste: onPaste,
         handleKeyDown: (view, event) => {
           if (onKeyDown !== undefined) {


### PR DESCRIPTION
Closes #10623
               
  ## Summary                                                                                                            
  Adds a configurable `spellcheck` boolean prop (default: `true`) to all text editor components, allowing spell checking
   to be disabled for users writing in non-English languages.                                                           
                                                                                                                        
  ## Changes
  - **TextEditor.svelte** — new `spellcheck` prop, merged into TipTap editor attributes                                 
  - **CollaborativeTextEditor.svelte** — same prop, passed through to editor attributes                               
  - **StyledTextEditor.svelte** — exposes prop and passes to inner TextEditor                                           
  - **CollaboratorEditor.svelte** — exposes prop and passes to CollaborativeTextEditor                                  
                                                                                                                        
  ## Usage                                                                                                              
  ```svelte                                                                                                             
  <!-- Disable spell checking -->                                                                                     
  <TextEditor spellcheck={false} />                                                                                     
                                                                                                                      
  <!-- Default behavior (spell checking enabled) -->
  <TextEditor />                                    

  Notes                                                                                                                 
   
  - Default is true to preserve existing behavior                                                                       
  - Sets the HTML spellcheck attribute on the contenteditable element                                                 
  - A user settings toggle can be wired up in a follow-up to persist this preference per user