### PR TITLE
fix(calendar): add error handling for outbound Google Calendar sync

### DIFF
--- a/services/calendar/pod-calendar/src/main.ts
+++ b/services/calendar/pod-calendar/src/main.ts
@@ -173,7 +173,9 @@ export const main = async (): Promise<void> => {
           res.status(400).send({ err: "'event' or 'workspace' or 'type' is missing" })
           return
         }
-        void OutcomingClient.push(ctx, accountClient, workspace, event, type)
+        void OutcomingClient.push(ctx, accountClient, workspace, event, type).catch((err: any) => {
+          ctx.error('Outcoming sync failed', { eventId: event.eventId, workspace, type, error: err.message })
+        })
         res.send()
       }
     }

--- a/services/calendar/pod-calendar/src/outcomingClient.ts
+++ b/services/calendar/pod-calendar/src/outcomingClient.ts
@@ -153,10 +153,20 @@ export class OutcomingClient {
     const calendarId = calendar.externalId
     if (calendarId !== undefined) {
       await this.rateLimiter.take(1)
-      await this.calendar.events.insert({
-        calendarId,
-        requestBody: body
-      })
+      try {
+        await this.calendar.events.insert({
+          calendarId,
+          requestBody: body
+        })
+      } catch (err: any) {
+        this.ctx.error('Google API insert error', {
+          calendarId,
+          eventId: event.eventId,
+          error: err.message,
+          code: err.code
+        })
+        throw err
+      }
     }
   }
 
@@ -380,17 +390,33 @@ export class OutcomingClient {
   }
 
   private async remove (eventId: string, calendarId: string): Promise<void> {
-    const current = await this.calendar.events.get({ calendarId, eventId })
-    if (current?.data !== undefined) {
-      if (current.data.organizer?.self === true) {
-        await this.rateLimiter.take(1)
-        try {
-          await this.calendar.events.delete({
-            eventId,
-            calendarId
-          })
-        } catch {}
+    try {
+      const current = await this.calendar.events.get({ calendarId, eventId })
+      if (current?.data !== undefined) {
+        if (current.data.organizer?.self === true) {
+          await this.rateLimiter.take(1)
+          try {
+            await this.calendar.events.delete({
+              eventId,
+              calendarId
+            })
+          } catch (err: any) {
+            this.ctx.error('Google API delete error', {
+              calendarId,
+              eventId,
+              error: err.message,
+              code: err.code
+            })
+          }
+        }
       }
+    } catch (err: any) {
+      this.ctx.error('Failed to get event for deletion', {
+        calendarId,
+        eventId,
+        error: err.message,
+        code: err.code
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

Add proper error handling to prevent silent failures when syncing events to Google Calendar.

## Problem

As described in #10535, outbound sync from Huly to Google Calendar was failing silently due to:

1. Unhandled promise rejections in the webhook handler
2. Missing try/catch blocks around Google API calls
3. Empty catch blocks that swallowed errors

## Changes

- **main.ts**: Add .catch() handler to log sync failures with event context
- **outcomingClient.ts**: Add try/catch in create() method to log Google API insert errors with calendarId, eventId, and error details
- **outcomingClient.ts**: Improve error handling in remove() method to properly log get/delete errors

## Testing

These changes ensure that:

- Sync failures are properly logged with context (eventId, workspace, error message)
- Google API errors include the HTTP status code for easier debugging
- Errors are no longer silently swallowed

Fixes #10535