### PR TITLE
Fix SQL operator does not exist

### DIFF
--- a/foundations/server/packages/postgres/src/__tests__/query-sql.spec.ts
+++ b/foundations/server/packages/postgres/src/__tests__/query-sql.spec.ts
@@ -68,7 +68,7 @@ describe('PostgresAdapter findAll SQL (top-level $and, empty $in)', () => {
       space: { $in: noSpaces }
     }
 
-    await adapter.findAll(ctx, test.class.ComplexClass, query)
+    await adapter.findAll(ctx as any, test.class.ComplexClass, query)
 
     expect(queries.length).toBeGreaterThan(0)
     const sql = queries[queries.length - 1]?.query ?? ''
@@ -84,7 +84,7 @@ describe('PostgresAdapter findAll SQL (top-level $and, empty $in)', () => {
 
     const noSpaces: Ref<Space>[] = []
     const q: DocumentQuery<ComplexClass> = { space: { $in: noSpaces } }
-    await adapter.findAll(ctx, test.class.ComplexClass, q)
+    await adapter.findAll(ctx as any, test.class.ComplexClass, q)
 
     const sql = queries[queries.length - 1]?.query ?? ''
     expect(sql).toContain('FALSE')
@@ -96,7 +96,7 @@ describe('PostgresAdapter findAll SQL (top-level $and, empty $in)', () => {
 
     const noIds: Ref<ComplexClass>[] = []
     const q: DocumentQuery<ComplexClass> = { _id: { $in: noIds } }
-    await adapter.findAll(ctx, test.class.ComplexClass, q)
+    await adapter.findAll(ctx as any, test.class.ComplexClass, q)
 
     const sql = queries[queries.length - 1]?.query ?? ''
     expect(sql).toContain('FALSE')

--- a/foundations/server/packages/postgres/src/__tests__/query-sql.spec.ts
+++ b/foundations/server/packages/postgres/src/__tests__/query-sql.spec.ts
@@ -1,0 +1,105 @@
+//
+// Copyright © 2026 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import {
+  type DocumentQuery,
+  Hierarchy,
+  MeasureMetricsContext,
+  ModelDb,
+  type Ref,
+  type Space,
+  type WorkspaceUuid
+} from '@hcengineering/core'
+import { ConnectionMgr } from '@hcengineering/postgres-base'
+import { PostgresAdapter } from '../storage'
+import { genMinModel, test, type ComplexClass } from './minmodel'
+import { createDummyClient, type TypedQuery } from './utils'
+
+function createAdapterWithQueryCapture (): {
+  adapter: PostgresAdapter
+  ctx: MeasureMetricsContext
+  queries: TypedQuery[]
+} {
+  const queries: TypedQuery[] = []
+  const client = createDummyClient(queries)
+  const minModel = genMinModel()
+  const hierarchy = new Hierarchy()
+  for (const tx of minModel) {
+    hierarchy.tx(tx)
+  }
+  const modelDb = new ModelDb(hierarchy)
+  const ctx = new MeasureMetricsContext('query-sql-test', {})
+  modelDb.addTxes(ctx, minModel, true)
+  const adapter = new PostgresAdapter(
+    client,
+    new ConnectionMgr(client),
+    {
+      url: () => 'test',
+      close: () => {}
+    },
+    'workspace' as WorkspaceUuid,
+    hierarchy,
+    modelDb,
+    'test'
+  )
+  return { adapter, ctx, queries }
+}
+
+describe('PostgresAdapter findAll SQL (top-level $and, empty $in)', () => {
+  it('does not treat $and as a JSON data path (security-style merged query)', async () => {
+    const { adapter, ctx, queries } = createAdapterWithQueryCapture()
+    const docId = '6968889052c59ef292857a08' as Ref<ComplexClass>
+    const noIds: Ref<ComplexClass>[] = []
+    const noSpaces: Ref<Space>[] = []
+    const query: DocumentQuery<ComplexClass> = {
+      $and: [{ _id: docId }, { _id: { $in: noIds } }],
+      space: { $in: noSpaces }
+    }
+
+    await adapter.findAll(ctx, test.class.ComplexClass, query)
+
+    expect(queries.length).toBeGreaterThan(0)
+    const sql = queries[queries.length - 1]?.query ?? ''
+    expect(sql).not.toMatch(/data#>>'\{\$and\}'/)
+    expect(sql).not.toMatch(/#>>'\{\$and\}'/)
+    expect(sql).toContain('FALSE')
+    expect(sql).not.toContain("IN ('NULL')")
+    expect(sql).toMatch(/_id/)
+  })
+
+  it("uses FALSE for empty $in on a column field (not IN ('NULL'))", async () => {
+    const { adapter, ctx, queries } = createAdapterWithQueryCapture()
+
+    const noSpaces: Ref<Space>[] = []
+    const q: DocumentQuery<ComplexClass> = { space: { $in: noSpaces } }
+    await adapter.findAll(ctx, test.class.ComplexClass, q)
+
+    const sql = queries[queries.length - 1]?.query ?? ''
+    expect(sql).toContain('FALSE')
+    expect(sql).not.toContain("IN ('NULL')")
+  })
+
+  it('uses FALSE for empty $in on _id alone', async () => {
+    const { adapter, ctx, queries } = createAdapterWithQueryCapture()
+
+    const noIds: Ref<ComplexClass>[] = []
+    const q: DocumentQuery<ComplexClass> = { _id: { $in: noIds } }
+    await adapter.findAll(ctx, test.class.ComplexClass, q)
+
+    const sql = queries[queries.length - 1]?.query ?? ''
+    expect(sql).toContain('FALSE')
+    expect(sql).not.toContain("IN ('NULL')")
+  })
+})

--- a/foundations/server/packages/postgres/src/storage.ts
+++ b/foundations/server/packages/postgres/src/storage.ts
@@ -1094,12 +1094,29 @@ abstract class PostgresAdapterBase implements DbAdapter {
     joins: JoinProps[],
     options?: ServerFindOptions<T>
   ): string {
-    const res: string[] = []
     const query = { ..._query }
+    const res: string[] = []
     res.push(`${baseDomain}."workspaceId" = ${vars.add(this.workspaceId, '::uuid')}`)
     if (options?.skipClass !== true) {
       query._class = this.fillClass(_class, query) as any
     }
+    res.push(...this.buildQueryClauses(vars, _class, baseDomain, query, joins, options))
+    return res.join(' AND ')
+  }
+
+  /**
+   * Builds AND fragments for a query object (workspace filter is handled in {@link buildQuery}).
+   * Supports top-level `$and` (e.g. from security middleware) as nested conjunctions.
+   */
+  private buildQueryClauses<T extends Doc>(
+    vars: ValuesVariables,
+    _class: Ref<Class<T>>,
+    baseDomain: string,
+    query: DocumentQuery<T>,
+    joins: JoinProps[],
+    options?: ServerFindOptions<T>
+  ): string[] {
+    const res: string[] = []
     for (const _key in query) {
       if (options?.skipSpace === true && _key === 'space') {
         continue
@@ -1109,6 +1126,23 @@ abstract class PostgresAdapterBase implements DbAdapter {
       }
       const value = query[_key]
       if (value === undefined) continue
+
+      if (_key === '$and') {
+        if (!Array.isArray(value)) continue
+        for (const rawSub of value as DocumentQuery<T>[]) {
+          if (rawSub == null || typeof rawSub !== 'object') continue
+          const sub: DocumentQuery<T> = { ...rawSub }
+          if (sub._class === undefined && query._class !== undefined) {
+            ;(sub as any)._class = query._class
+          }
+          const nested = this.buildQueryClauses(vars, _class, baseDomain, sub, joins, options)
+          if (nested.length > 0) {
+            res.push(`(${nested.join(' AND ')})`)
+          }
+        }
+        continue
+      }
+
       const key = escape(_key)
       const valueType = this.getValueType(_class, key)
       const tkey = this.getKey(_class, baseDomain, key, joins, valueType === 'dataArray')
@@ -1117,7 +1151,7 @@ abstract class PostgresAdapterBase implements DbAdapter {
         res.push(translated)
       }
     }
-    return res.join(' AND ')
+    return res
   }
 
   private getValueType<T extends Doc>(_class: Ref<Class<T>>, key: string): ValueType {
@@ -1335,7 +1369,7 @@ abstract class PostgresAdapterBase implements DbAdapter {
                   if (val.length > 0) {
                     res.push(`${tlkey} = ANY(${vars.addArray(val, valType)})`)
                   } else {
-                    res.push(`${tlkey} IN ('NULL')`)
+                    res.push('FALSE')
                   }
                 }
                 break


### PR DESCRIPTION
Fix `PostgresError: operator does not exist: text = text[]`:

```{"_class":"documents:class:ControlledDocument","err":{"code":"42883","file":"parse_oper.c","hint":"No operator matches the given name and argument types. 
You might need to add explicit type casts.","line":"647", "message":
"operator does not exist: text = text[]","name":"PostgresError","position":"140","routine":"op_error","severity":"ERROR","severity_local":
"ERROR","stack":"PostgresError: operator does not exist: text = text[]\n    at ErrorResponse (/usr/src/app/bundle.js:145547:31)\n    at handle (/usr/src/app/bundle.js:145304:11)\n    at Socket.data2 (/usr/src/app/bundle.js:145113:13)\n    at Socket.emit (node:events:519:28)\n    at addChunk (node:internal/streams/readable:561:12)\n    at 
readableAddChunkPushByteMode (node:internal/streams/readable:512:3)\n    at Readable.push (node:internal/streams/readable:392:5)\n    at TCP.onStreamRead (node:internal/stream_base_commons:189:23)\n    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)"},"level":"error","message":"Error in findAll","query":{"$and":[{"_id":"6968889052c59ef292857a08"},{"_id":{"$in":[]}}],"space":{"$in":[]}},"source":"🤦‍♂️user","sql":"SELECT documents.* FROM documents WHERE documents.\"workspaceId\" = $1::uuid AND documents.\"space\" IN ('NULL') AND documents.data#>>'{$and}' = $2::text[] AND documents.\"_class\" = $3::text AND (EXISTS (SELECT 1 FROM space sec WHERE sec._id = documents.space AND sec.\"workspaceId\" = $1::uuid AND (sec._id = 'core:space:Space' OR sec.\"_class\" = 'core:class:SystemSpace' OR sec.members @> '{\"83bbed9a-0867-4851-be32-31d49d1d42ce\"}') AND sec.archived = false) OR EXISTS (SELECT 1 FROM collaborator collab_sec WHERE collab_sec.\"workspaceId\" = $1::uuid AND collab_sec.\"attachedTo\" = documents._id AND collab_sec.collaborator = '83bbed9a-0867-4851-be32-31d49d1d42ce')) LIMIT 1","sqlFull":"SELECT documents.* FROM documents WHERE documents.\"workspaceId\" = 'a1c6ac6e-fd92-4e91-98f8-0d7007f49889'::uuid AND documents.\"space\" IN ('NULL') AND documents.data#>>'{$and}' = ARRAY['[object Object]','[object Object]']::text[] AND documents.\"_class\" = 'documents:class:ControlledDocument'::text AND (EXISTS (SELECT 1 FROM space sec WHERE sec._id = documents.space AND sec.\"workspaceId\" = 'a1c6ac6e-fd92-4e91-98f8-0d7007f49889'::uuid AND (sec._id = 'core:space:Space' OR sec.\"_class\" = 'core:class:SystemSpace' OR sec.members @> '{\"83bbed9a-0867-4851-be32-31d49d1d42ce\"}') AND sec.archived = false) OR EXISTS (SELECT 1 FROM collaborator collab_sec WHERE collab_sec.\"workspaceId\" = 'a1c6ac6e-fd92-4e91-98f8-0d7007f49889'::uuid AND collab_sec.\"attachedTo\" = documents._id AND collab_sec.collaborator = '83bbed9a-0867-4851-be32-31d49d1d42ce')) LIMIT 1","timestamp":"2026-04-13T03:10:10.936Z"}```