### PR TITLE
fix(ci): emit TypeScript declarations before npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,6 +34,8 @@ jobs:
         run: node common/scripts/install-run-rush.js install
       - name: Building...
         run: node common/scripts/install-run-rush.js build
+      - name: Emit TypeScript declarations
+        run: node common/scripts/install-run-rush.js validate
       - name: Publish to npm
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Published tarballs of several @hcengineering/* packages (0.7.411+) are missing their .d.ts files, despite every package.json declaring "types": "types/index.d.ts" and listing "types/**/*" in "files".

  Repro: npm pack @hcengineering/core@0.7.413 --dry-run --json
         (no `types/` entries in the file list)

Root cause
----------
`publish-npm.yml` runs `rush build`, which is defined in `common/config/rush/command-line.json` as a phased command with `"phases": ["_phase:build"]`. `_phase:build` resolves to `compile transpile src` (an esbuild-only transpile → `lib/`). The `.d.ts` emit lives in a separate phase, `_phase:validate` (`compile validate` → `tsc --emitDeclarationOnly` → `declarationDir: ./types`), which the publish workflow never runs. Because `types/` does not exist when safe-publish.js invokes `npm publish`, the `types/**/*` glob in each package's `files` field matches nothing and the tarball ships without declarations.

Why this didn't regress earlier
-------------------------------
These packages used to live in the now-dormant `hcengineering/huly.core` repo. That repo's `ci.yml` explicitly ran `rush validate` before `rush publish`, so `types/` was always present at publish time.

After migration into this monorepo, the publish pipeline was rewritten (PR #10542, then extracted to `publish-npm.yml` in PR #10580) and the validate step was not carried over. Versions 0.7.18–0.7.382 still shipped declarations because:

  - 0.7.18–0.7.26 were published from `huly.core` (validate present).
  - 0.7.382 was published manually (likely) from a developer machine (`_nodeVersion: 22.13.0, _npmVersion: 11.0.0` in npm metadata - doesn't match the CI runner). `types/` happened to be left on disk from prior local development.
  - 0.7.411+ are (likely) the first versions published via `publish-npm.yml` on a fresh runner (`_nodeVersion: 22.22.2, _npmVersion: 10.9.7`, consistent with actions/setup-node@v6 resolving `.nvmrc: v22`). 

Fix
---
Add a `rush validate` step between build and publish in `publish-npm.yml`. 

Affected packages observed on npm (0.7.411+):
  @hcengineering/core
  @hcengineering/account-client
  @hcengineering/api-client
  @hcengineering/text
  @hcengineering/text-core
  @hcengineering/text-html

Fixes #10767

