### PR TITLE
Fix/new category crash 10772

### DIFF
--- a/plugins/controlled-documents-resources/src/components/Categories.svelte
+++ b/plugins/controlled-documents-resources/src/components/Categories.svelte
@@ -39,7 +39,7 @@
   const _class: Ref<Class<DocumentCategory>> = document.class.DocumentCategory
 
   function showCreateDialog (): void {
-    showPopup(CreateDocumentCategory, {}, 'top')
+    showPopup(CreateDocumentCategory, { space }, 'top')
   }
 </script>
 

--- a/plugins/controlled-documents-resources/src/components/CreateDocumentCategory.svelte
+++ b/plugins/controlled-documents-resources/src/components/CreateDocumentCategory.svelte
@@ -15,13 +15,13 @@
 //
 -->
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import { createEventDispatcher, onMount } from 'svelte'
   import { Attachment } from '@hcengineering/attachment'
   import { AttachmentPresenter, AttachmentStyledBox } from '@hcengineering/attachment-resources'
   import { generateId, Ref, Space } from '@hcengineering/core'
   import { Card, getClient } from '@hcengineering/presentation'
   import { Button, EditBox, IconAttachment, tooltip } from '@hcengineering/ui'
-  import { DocumentCategory } from '@hcengineering/controlled-documents'
+  import { DocumentCategory, DocumentSpace } from '@hcengineering/controlled-documents'
 
   import IconWarning from './icons/IconWarning.svelte'
   import documents from '../plugin'
@@ -37,9 +37,18 @@
   const dispatch = createEventDispatcher()
   const client = getClient()
   let descriptionBox: AttachmentStyledBox
+  let spaceExists = true
+
+  onMount(async () => {
+    const spaceDoc = await client.findOne(documents.class.DocumentSpace, { _id: space as Ref<DocumentSpace> })
+    spaceExists = spaceDoc !== undefined
+    if (!spaceExists) {
+      console.error(`Document space ${space} not found. Category cannot be created.`)
+    }
+  })
 
   async function handleOkAction (): Promise<void> {
-    if (isCodeWrong || isTitleWrong) {
+    if (isCodeWrong || isTitleWrong || !spaceExists) {
       return
     }
     const op = client.apply()
@@ -61,7 +70,7 @@
 
   let existingCategories: string[] = []
   let existingCodes: string[] = []
-  $: void client.findAll(documents.class.DocumentCategory, {}).then((cats) => {
+  $: void client.findAll(documents.class.DocumentCategory, { space }).then((cats) => {
     existingCategories = cats.map((cat) => cat.title)
     existingCodes = cats.map((cat) => cat.code)
   })
@@ -82,7 +91,7 @@
 <Card
   label={documents.string.CreateDocumentCategory}
   okAction={handleOkAction}
-  canSave={!isCodeWrong && !isTitleWrong}
+  canSave={!isCodeWrong && !isTitleWrong && spaceExists}
   hideAttachments={attachments.size === 0}
   on:close={() => {
     dispatch('close')


### PR DESCRIPTION
Root Cause
CreateDocumentCategory defaulted space to documents.space.QualityDocuments. On workspaces where the QMS space wasn't initialized (a data state possible after certain upgrades / non-QMS workspaces), the space reference was invalid:

[NewDocumentHeader.svelte:60](vscode-webview://05ep8e8jvqngboohnbtjfa5d0ckq4hqd6f3l175eqlfgofbn99pf/platform/plugins/controlled-documents-resources/src/components/NewDocumentHeader.svelte#L60) called showPopup(CreateDocumentCategory, {}) with empty props, always relying on the default.
[Categories.svelte:42](vscode-webview://05ep8e8jvqngboohnbtjfa5d0ckq4hqd6f3l175eqlfgofbn99pf/platform/plugins/controlled-documents-resources/src/components/Categories.svelte#L42) did the same even though it already had a valid space in scope.
createDoc() then submitted a transaction against a non-existent space → failed TxUpdateDoc transactions → UI crash.

Fix
Categories.svelte — pass the in-scope space to CreateDocumentCategory instead of relying on the default.
CreateDocumentCategory.svelte — verify the target DocumentSpace exists in onMount. If missing, disable the Save button (canSave = false) and log a clear error, preventing the crashing transaction. Also scope the existing-category/code lookup with { space } so duplicate-checks are correct per space.